### PR TITLE
fix: properly parse text starting with a number

### DIFF
--- a/common/define-grammar.js
+++ b/common/define-grammar.js
@@ -29,19 +29,16 @@ module.exports = function defineGrammar(dialect, separator) {
         optional($.row),
       ),
 
-      row: $ => choice(
-        seq(repeat(separator), $.field, repeat(seq(repeat(separator), $.field)), repeat(separator)),
-        repeat1(separator),
-      ),
+      row: $ => seq($.field, repeat(seq(separator, $.field))),
       field: $ => choice($.text, $.number, $.float, $.boolean),
 
-      text: _ => token(choice(
-        new RegExp(`[^${separator}\\d\\s"][^${separator} \\n\\r"]+`),
-        seq('"', repeat(choice(/[^"]/, '""')), '"'),
-      )),
       number: _ => choice(/\d+/, /0[xX][0-9a-fA-F]+/),
       float: _ => choice(/\d*\.\d+/, /\d+\.\d*/),
       boolean: _ => choice('true', 'false'),
+      text: _ => token(choice(
+        new RegExp(`[^${separator}\\r\\n]*`),
+        seq('"', repeat(choice(/[^"]/, '""')), '"'),
+      )),
     },
   });
 };

--- a/csv/src/grammar.json
+++ b/csv/src/grammar.json
@@ -35,55 +35,26 @@
       ]
     },
     "row": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "STRING",
-                "value": ","
-              }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "field"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "STRING",
-                      "value": ","
-                    }
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "field"
-                  }
-                ]
-              }
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "STRING",
-                "value": ","
-              }
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "field"
         },
         {
-          "type": "REPEAT1",
+          "type": "REPEAT",
           "content": {
-            "type": "STRING",
-            "value": ","
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "SYMBOL",
+                "name": "field"
+              }
+            ]
           }
         }
       ]
@@ -108,47 +79,6 @@
           "name": "boolean"
         }
       ]
-    },
-    "text": {
-      "type": "TOKEN",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "PATTERN",
-            "value": "[^,\\d\\s\"][^, \\n\\r\"]+"
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "\""
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "[^\"]"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "\"\""
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "STRING",
-                "value": "\""
-              }
-            ]
-          }
-        ]
-      }
     },
     "number": {
       "type": "CHOICE",
@@ -188,6 +118,47 @@
           "value": "false"
         }
       ]
+    },
+    "text": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "PATTERN",
+            "value": "[^,\\r\\n]*"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\""
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "PATTERN",
+                      "value": "[^\"]"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "\"\""
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "STRING",
+                "value": "\""
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   "extras": [
@@ -202,3 +173,4 @@
   "inline": [],
   "supertypes": []
 }
+

--- a/csv/src/node-types.json
+++ b/csv/src/node-types.json
@@ -62,7 +62,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "field",

--- a/csv/src/parser.c
+++ b/csv/src/parser.c
@@ -1,30 +1,31 @@
-#include "tree_sitter/parser.h"
+#include <tree_sitter/parser.h>
 
 #if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 42
-#define LARGE_STATE_COUNT 31
-#define SYMBOL_COUNT 19
+#define STATE_COUNT 27
+#define LARGE_STATE_COUNT 6
+#define SYMBOL_COUNT 18
 #define ALIAS_COUNT 0
 #define TOKEN_COUNT 10
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 0
-#define MAX_ALIAS_SEQUENCE_LENGTH 4
+#define MAX_ALIAS_SEQUENCE_LENGTH 2
 #define PRODUCTION_ID_COUNT 1
 
-enum ts_symbol_identifiers {
+enum {
   aux_sym_document_token1 = 1,
   anon_sym_COMMA = 2,
-  sym_text = 3,
-  aux_sym_number_token1 = 4,
-  aux_sym_number_token2 = 5,
-  aux_sym_float_token1 = 6,
-  aux_sym_float_token2 = 7,
-  anon_sym_true = 8,
-  anon_sym_false = 9,
+  aux_sym_number_token1 = 3,
+  aux_sym_number_token2 = 4,
+  aux_sym_float_token1 = 5,
+  aux_sym_float_token2 = 6,
+  anon_sym_true = 7,
+  anon_sym_false = 8,
+  sym_text = 9,
   sym_document = 10,
   sym_row = 11,
   sym_field = 12,
@@ -33,20 +34,19 @@ enum ts_symbol_identifiers {
   sym_boolean = 15,
   aux_sym_document_repeat1 = 16,
   aux_sym_row_repeat1 = 17,
-  aux_sym_row_repeat2 = 18,
 };
 
 static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
   [aux_sym_document_token1] = "document_token1",
   [anon_sym_COMMA] = ",",
-  [sym_text] = "text",
   [aux_sym_number_token1] = "number_token1",
   [aux_sym_number_token2] = "number_token2",
   [aux_sym_float_token1] = "float_token1",
   [aux_sym_float_token2] = "float_token2",
   [anon_sym_true] = "true",
   [anon_sym_false] = "false",
+  [sym_text] = "text",
   [sym_document] = "document",
   [sym_row] = "row",
   [sym_field] = "field",
@@ -55,20 +55,19 @@ static const char * const ts_symbol_names[] = {
   [sym_boolean] = "boolean",
   [aux_sym_document_repeat1] = "document_repeat1",
   [aux_sym_row_repeat1] = "row_repeat1",
-  [aux_sym_row_repeat2] = "row_repeat2",
 };
 
 static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
   [aux_sym_document_token1] = aux_sym_document_token1,
   [anon_sym_COMMA] = anon_sym_COMMA,
-  [sym_text] = sym_text,
   [aux_sym_number_token1] = aux_sym_number_token1,
   [aux_sym_number_token2] = aux_sym_number_token2,
   [aux_sym_float_token1] = aux_sym_float_token1,
   [aux_sym_float_token2] = aux_sym_float_token2,
   [anon_sym_true] = anon_sym_true,
   [anon_sym_false] = anon_sym_false,
+  [sym_text] = sym_text,
   [sym_document] = sym_document,
   [sym_row] = sym_row,
   [sym_field] = sym_field,
@@ -77,7 +76,6 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_boolean] = sym_boolean,
   [aux_sym_document_repeat1] = aux_sym_document_repeat1,
   [aux_sym_row_repeat1] = aux_sym_row_repeat1,
-  [aux_sym_row_repeat2] = aux_sym_row_repeat2,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -92,10 +90,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [anon_sym_COMMA] = {
     .visible = true,
     .named = false,
-  },
-  [sym_text] = {
-    .visible = true,
-    .named = true,
   },
   [aux_sym_number_token1] = {
     .visible = false,
@@ -120,6 +114,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [anon_sym_false] = {
     .visible = true,
     .named = false,
+  },
+  [sym_text] = {
+    .visible = true,
+    .named = true,
   },
   [sym_document] = {
     .visible = true,
@@ -153,10 +151,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_row_repeat2] = {
-    .visible = false,
-    .named = false,
-  },
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
@@ -173,43 +167,28 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [2] = 2,
   [3] = 3,
   [4] = 4,
-  [5] = 5,
+  [5] = 4,
   [6] = 6,
   [7] = 7,
   [8] = 8,
   [9] = 9,
-  [10] = 8,
+  [10] = 7,
   [11] = 11,
-  [12] = 3,
-  [13] = 4,
-  [14] = 5,
-  [15] = 15,
-  [16] = 7,
+  [12] = 12,
+  [13] = 13,
+  [14] = 14,
+  [15] = 9,
+  [16] = 8,
   [17] = 17,
-  [18] = 17,
-  [19] = 15,
-  [20] = 11,
-  [21] = 9,
+  [18] = 11,
+  [19] = 12,
+  [20] = 13,
+  [21] = 14,
   [22] = 22,
-  [23] = 22,
+  [23] = 17,
   [24] = 24,
-  [25] = 24,
+  [25] = 25,
   [26] = 26,
-  [27] = 27,
-  [28] = 28,
-  [29] = 29,
-  [30] = 30,
-  [31] = 26,
-  [32] = 27,
-  [33] = 29,
-  [34] = 34,
-  [35] = 30,
-  [36] = 28,
-  [37] = 24,
-  [38] = 38,
-  [39] = 39,
-  [40] = 40,
-  [41] = 41,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -217,206 +196,293 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(8);
-      ADVANCE_MAP(
-        '\n', 9,
-        '\r', 9,
-        '"', 1,
-        ',', 10,
-        '.', 4,
-        '0', 19,
-        'f', 2,
-        't', 3,
-      );
-      if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') SKIP(0);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(20);
-      if (lookahead != 0) ADVANCE(6);
+      if (eof) ADVANCE(12);
+      if (lookahead == ',') ADVANCE(14);
+      if (lookahead == '.') ADVANCE(9);
+      if (lookahead == '0') ADVANCE(15);
+      if (lookahead == 'f') ADVANCE(2);
+      if (lookahead == 't') ADVANCE(6);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(0)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(16);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(11);
+      if (lookahead == '"') ADVANCE(32);
       if (lookahead != 0) ADVANCE(1);
       END_STATE();
     case 2:
-      if (lookahead == 'a') ADVANCE(14);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
+      if (lookahead == 'a') ADVANCE(5);
       END_STATE();
     case 3:
-      if (lookahead == 'r') ADVANCE(16);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
+      if (lookahead == 'e') ADVANCE(25);
       END_STATE();
     case 4:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(17);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
+      if (lookahead == 'e') ADVANCE(27);
       END_STATE();
     case 5:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(21);
+      if (lookahead == 'l') ADVANCE(7);
       END_STATE();
     case 6:
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
+      if (lookahead == 'r') ADVANCE(8);
       END_STATE();
     case 7:
-      if (eof) ADVANCE(8);
-      if (lookahead == '"') ADVANCE(1);
-      if (lookahead == ',') ADVANCE(10);
-      if (lookahead == '.') ADVANCE(4);
-      if (lookahead == '0') ADVANCE(19);
-      if (lookahead == 'f') ADVANCE(2);
-      if (lookahead == 't') ADVANCE(3);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(7);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(20);
-      if (lookahead != 0) ADVANCE(6);
+      if (lookahead == 's') ADVANCE(4);
       END_STATE();
     case 8:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (lookahead == 'u') ADVANCE(3);
       END_STATE();
     case 9:
-      ACCEPT_TOKEN(aux_sym_document_token1);
-      if (lookahead == '\n') ADVANCE(9);
-      if (lookahead == '\r') ADVANCE(9);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(21);
       END_STATE();
     case 10:
-      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(19);
       END_STATE();
     case 11:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == '"') ADVANCE(1);
+      if (eof) ADVANCE(12);
+      if (lookahead == '\n') ADVANCE(13);
+      if (lookahead == '\r') ADVANCE(13);
+      if (lookahead == ',') ADVANCE(14);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(11)
       END_STATE();
     case 12:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e') ADVANCE(24);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 13:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e') ADVANCE(25);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
+      ACCEPT_TOKEN(aux_sym_document_token1);
+      if (lookahead == '\n') ADVANCE(13);
+      if (lookahead == '\r') ADVANCE(13);
       END_STATE();
     case 14:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l') ADVANCE(15);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
+      ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 15:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 's') ADVANCE(13);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
-      END_STATE();
-    case 16:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'u') ADVANCE(12);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
-      END_STATE();
-    case 17:
-      ACCEPT_TOKEN(sym_text);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(17);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
-      END_STATE();
-    case 18:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
-      END_STATE();
-    case 19:
       ACCEPT_TOKEN(aux_sym_number_token1);
       if (lookahead == '.') ADVANCE(23);
       if (lookahead == 'X' ||
-          lookahead == 'x') ADVANCE(5);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(20);
+          lookahead == 'x') ADVANCE(10);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(16);
       END_STATE();
-    case 20:
+    case 16:
       ACCEPT_TOKEN(aux_sym_number_token1);
       if (lookahead == '.') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(20);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(16);
       END_STATE();
-    case 21:
+    case 17:
+      ACCEPT_TOKEN(aux_sym_number_token1);
+      if (lookahead == '.') ADVANCE(24);
+      if (lookahead == 'X' ||
+          lookahead == 'x') ADVANCE(41);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(18);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 18:
+      ACCEPT_TOKEN(aux_sym_number_token1);
+      if (lookahead == '.') ADVANCE(24);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(18);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 19:
       ACCEPT_TOKEN(aux_sym_number_token2);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(21);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(19);
+      END_STATE();
+    case 20:
+      ACCEPT_TOKEN(aux_sym_number_token2);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(20);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 21:
+      ACCEPT_TOKEN(aux_sym_float_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(21);
       END_STATE();
     case 22:
       ACCEPT_TOKEN(aux_sym_float_token1);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(22);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
       END_STATE();
     case 23:
       ACCEPT_TOKEN(aux_sym_float_token2);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(22);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(21);
       END_STATE();
     case 24:
+      ACCEPT_TOKEN(aux_sym_float_token2);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(22);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 25:
+      ACCEPT_TOKEN(anon_sym_true);
+      END_STATE();
+    case 26:
       ACCEPT_TOKEN(anon_sym_true);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
+          lookahead != ',') ADVANCE(42);
       END_STATE();
-    case 25:
+    case 27:
+      ACCEPT_TOKEN(anon_sym_false);
+      END_STATE();
+    case 28:
       ACCEPT_TOKEN(anon_sym_false);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != ',') ADVANCE(18);
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 29:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '"') ADVANCE(31);
+      if (lookahead == '.') ADVANCE(40);
+      if (lookahead == '0') ADVANCE(17);
+      if (lookahead == 'f') ADVANCE(33);
+      if (lookahead == 't') ADVANCE(37);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(29);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(18);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 30:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '"') ADVANCE(31);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 31:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '"') ADVANCE(30);
+      if (lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ',') ADVANCE(1);
+      if (lookahead != 0) ADVANCE(31);
+      END_STATE();
+    case 32:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '"') ADVANCE(1);
+      END_STATE();
+    case 33:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'a') ADVANCE(36);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 34:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'e') ADVANCE(26);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 35:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'e') ADVANCE(28);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 36:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'l') ADVANCE(38);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 37:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'r') ADVANCE(39);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 38:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 's') ADVANCE(35);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 39:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'u') ADVANCE(34);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 40:
+      ACCEPT_TOKEN(sym_text);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(22);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 41:
+      ACCEPT_TOKEN(sym_text);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(20);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 42:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
+      END_STATE();
+    case 43:
+      ACCEPT_TOKEN(sym_text);
+      if (eof) ADVANCE(12);
+      if (lookahead == '"') ADVANCE(31);
+      if (lookahead == '.') ADVANCE(40);
+      if (lookahead == '0') ADVANCE(17);
+      if (lookahead == 'f') ADVANCE(33);
+      if (lookahead == 't') ADVANCE(37);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(29);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(18);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ',') ADVANCE(42);
       END_STATE();
     default:
       return false;
@@ -425,55 +491,38 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 7},
-  [2] = {.lex_state = 7},
-  [3] = {.lex_state = 0},
-  [4] = {.lex_state = 0},
-  [5] = {.lex_state = 0},
-  [6] = {.lex_state = 7},
-  [7] = {.lex_state = 0},
-  [8] = {.lex_state = 0},
-  [9] = {.lex_state = 0},
-  [10] = {.lex_state = 0},
-  [11] = {.lex_state = 0},
-  [12] = {.lex_state = 0},
-  [13] = {.lex_state = 0},
-  [14] = {.lex_state = 0},
-  [15] = {.lex_state = 0},
-  [16] = {.lex_state = 0},
-  [17] = {.lex_state = 0},
-  [18] = {.lex_state = 0},
-  [19] = {.lex_state = 0},
-  [20] = {.lex_state = 0},
-  [21] = {.lex_state = 0},
-  [22] = {.lex_state = 7},
-  [23] = {.lex_state = 7},
-  [24] = {.lex_state = 0},
-  [25] = {.lex_state = 0},
+  [1] = {.lex_state = 43},
+  [2] = {.lex_state = 43},
+  [3] = {.lex_state = 43},
+  [4] = {.lex_state = 43},
+  [5] = {.lex_state = 43},
+  [6] = {.lex_state = 43},
+  [7] = {.lex_state = 11},
+  [8] = {.lex_state = 11},
+  [9] = {.lex_state = 11},
+  [10] = {.lex_state = 11},
+  [11] = {.lex_state = 11},
+  [12] = {.lex_state = 11},
+  [13] = {.lex_state = 11},
+  [14] = {.lex_state = 11},
+  [15] = {.lex_state = 11},
+  [16] = {.lex_state = 11},
+  [17] = {.lex_state = 11},
+  [18] = {.lex_state = 11},
+  [19] = {.lex_state = 11},
+  [20] = {.lex_state = 11},
+  [21] = {.lex_state = 11},
+  [22] = {.lex_state = 11},
+  [23] = {.lex_state = 11},
+  [24] = {.lex_state = 11},
+  [25] = {.lex_state = 11},
   [26] = {.lex_state = 0},
-  [27] = {.lex_state = 0},
-  [28] = {.lex_state = 0},
-  [29] = {.lex_state = 0},
-  [30] = {.lex_state = 0},
-  [31] = {.lex_state = 0},
-  [32] = {.lex_state = 0},
-  [33] = {.lex_state = 0},
-  [34] = {.lex_state = 7},
-  [35] = {.lex_state = 0},
-  [36] = {.lex_state = 0},
-  [37] = {.lex_state = 7},
-  [38] = {.lex_state = 0},
-  [39] = {.lex_state = 0},
-  [40] = {.lex_state = 0},
-  [41] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
-    [aux_sym_document_token1] = ACTIONS(1),
     [anon_sym_COMMA] = ACTIONS(1),
-    [sym_text] = ACTIONS(1),
     [aux_sym_number_token1] = ACTIONS(1),
     [aux_sym_number_token2] = ACTIONS(1),
     [aux_sym_float_token1] = ACTIONS(1),
@@ -482,682 +531,284 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_false] = ACTIONS(1),
   },
   [1] = {
-    [sym_document] = STATE(41),
-    [sym_row] = STATE(38),
-    [sym_field] = STATE(8),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
+    [sym_document] = STATE(26),
+    [sym_row] = STATE(24),
+    [sym_field] = STATE(7),
+    [sym_number] = STATE(14),
+    [sym_float] = STATE(14),
+    [sym_boolean] = STATE(14),
     [aux_sym_document_repeat1] = STATE(2),
-    [aux_sym_row_repeat1] = STATE(9),
     [ts_builtin_sym_end] = ACTIONS(3),
-    [anon_sym_COMMA] = ACTIONS(5),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(11),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
+    [aux_sym_number_token1] = ACTIONS(5),
+    [aux_sym_number_token2] = ACTIONS(5),
+    [aux_sym_float_token1] = ACTIONS(7),
+    [aux_sym_float_token2] = ACTIONS(7),
+    [anon_sym_true] = ACTIONS(9),
+    [anon_sym_false] = ACTIONS(9),
+    [sym_text] = ACTIONS(11),
   },
   [2] = {
-    [sym_row] = STATE(39),
-    [sym_field] = STATE(8),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_document_repeat1] = STATE(6),
-    [aux_sym_row_repeat1] = STATE(9),
-    [ts_builtin_sym_end] = ACTIONS(17),
-    [anon_sym_COMMA] = ACTIONS(5),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(11),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
+    [sym_row] = STATE(22),
+    [sym_field] = STATE(7),
+    [sym_number] = STATE(14),
+    [sym_float] = STATE(14),
+    [sym_boolean] = STATE(14),
+    [aux_sym_document_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(13),
+    [aux_sym_number_token1] = ACTIONS(5),
+    [aux_sym_number_token2] = ACTIONS(5),
+    [aux_sym_float_token1] = ACTIONS(7),
+    [aux_sym_float_token2] = ACTIONS(7),
+    [anon_sym_true] = ACTIONS(9),
+    [anon_sym_false] = ACTIONS(9),
+    [sym_text] = ACTIONS(11),
   },
   [3] = {
-    [sym_field] = STATE(4),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(17),
-    [aux_sym_row_repeat2] = STATE(4),
-    [ts_builtin_sym_end] = ACTIONS(19),
-    [aux_sym_document_token1] = ACTIONS(19),
-    [anon_sym_COMMA] = ACTIONS(21),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
+    [sym_row] = STATE(25),
+    [sym_field] = STATE(10),
+    [sym_number] = STATE(21),
+    [sym_float] = STATE(21),
+    [sym_boolean] = STATE(21),
+    [aux_sym_document_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(15),
+    [aux_sym_number_token1] = ACTIONS(17),
+    [aux_sym_number_token2] = ACTIONS(17),
+    [aux_sym_float_token1] = ACTIONS(20),
+    [aux_sym_float_token2] = ACTIONS(20),
+    [anon_sym_true] = ACTIONS(23),
+    [anon_sym_false] = ACTIONS(23),
+    [sym_text] = ACTIONS(26),
   },
   [4] = {
-    [sym_field] = STATE(4),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(23),
-    [aux_sym_row_repeat2] = STATE(4),
-    [ts_builtin_sym_end] = ACTIONS(23),
-    [aux_sym_document_token1] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(25),
-    [sym_text] = ACTIONS(28),
-    [aux_sym_number_token1] = ACTIONS(31),
-    [aux_sym_number_token2] = ACTIONS(31),
-    [aux_sym_float_token1] = ACTIONS(34),
-    [aux_sym_float_token2] = ACTIONS(34),
-    [anon_sym_true] = ACTIONS(37),
-    [anon_sym_false] = ACTIONS(37),
+    [sym_field] = STATE(17),
+    [sym_number] = STATE(14),
+    [sym_float] = STATE(14),
+    [sym_boolean] = STATE(14),
+    [aux_sym_number_token1] = ACTIONS(5),
+    [aux_sym_number_token2] = ACTIONS(5),
+    [aux_sym_float_token1] = ACTIONS(7),
+    [aux_sym_float_token2] = ACTIONS(7),
+    [anon_sym_true] = ACTIONS(9),
+    [anon_sym_false] = ACTIONS(9),
+    [sym_text] = ACTIONS(11),
   },
   [5] = {
-    [sym_field] = STATE(3),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(15),
-    [aux_sym_row_repeat2] = STATE(3),
-    [ts_builtin_sym_end] = ACTIONS(40),
-    [aux_sym_document_token1] = ACTIONS(40),
-    [anon_sym_COMMA] = ACTIONS(42),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [6] = {
-    [sym_row] = STATE(40),
-    [sym_field] = STATE(10),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_document_repeat1] = STATE(6),
-    [aux_sym_row_repeat1] = STATE(21),
-    [ts_builtin_sym_end] = ACTIONS(44),
-    [anon_sym_COMMA] = ACTIONS(46),
-    [sym_text] = ACTIONS(49),
-    [aux_sym_number_token1] = ACTIONS(52),
-    [aux_sym_number_token2] = ACTIONS(55),
-    [aux_sym_float_token1] = ACTIONS(58),
-    [aux_sym_float_token2] = ACTIONS(58),
-    [anon_sym_true] = ACTIONS(61),
-    [anon_sym_false] = ACTIONS(61),
-  },
-  [7] = {
-    [sym_field] = STATE(4),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(15),
-    [aux_sym_row_repeat2] = STATE(4),
-    [ts_builtin_sym_end] = ACTIONS(40),
-    [aux_sym_document_token1] = ACTIONS(40),
-    [anon_sym_COMMA] = ACTIONS(42),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [8] = {
-    [sym_field] = STATE(7),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(11),
-    [aux_sym_row_repeat2] = STATE(7),
-    [ts_builtin_sym_end] = ACTIONS(64),
-    [aux_sym_document_token1] = ACTIONS(64),
-    [anon_sym_COMMA] = ACTIONS(66),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [9] = {
-    [sym_field] = STATE(5),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(64),
-    [aux_sym_document_token1] = ACTIONS(64),
-    [anon_sym_COMMA] = ACTIONS(68),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [10] = {
-    [sym_field] = STATE(16),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(20),
-    [aux_sym_row_repeat2] = STATE(16),
-    [aux_sym_document_token1] = ACTIONS(64),
-    [anon_sym_COMMA] = ACTIONS(70),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [11] = {
-    [sym_field] = STATE(28),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(40),
-    [aux_sym_document_token1] = ACTIONS(40),
-    [anon_sym_COMMA] = ACTIONS(68),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [12] = {
-    [sym_field] = STATE(13),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(18),
-    [aux_sym_row_repeat2] = STATE(13),
-    [aux_sym_document_token1] = ACTIONS(19),
-    [anon_sym_COMMA] = ACTIONS(80),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [13] = {
-    [sym_field] = STATE(13),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(22),
-    [aux_sym_row_repeat2] = STATE(13),
-    [aux_sym_document_token1] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(82),
-    [sym_text] = ACTIONS(85),
-    [aux_sym_number_token1] = ACTIONS(88),
-    [aux_sym_number_token2] = ACTIONS(88),
-    [aux_sym_float_token1] = ACTIONS(91),
-    [aux_sym_float_token2] = ACTIONS(91),
-    [anon_sym_true] = ACTIONS(94),
-    [anon_sym_false] = ACTIONS(94),
-  },
-  [14] = {
-    [sym_field] = STATE(12),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(19),
-    [aux_sym_row_repeat2] = STATE(12),
-    [aux_sym_document_token1] = ACTIONS(40),
-    [anon_sym_COMMA] = ACTIONS(97),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [15] = {
-    [sym_field] = STATE(28),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(19),
-    [aux_sym_document_token1] = ACTIONS(19),
-    [anon_sym_COMMA] = ACTIONS(68),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [16] = {
-    [sym_field] = STATE(13),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(19),
-    [aux_sym_row_repeat2] = STATE(13),
-    [aux_sym_document_token1] = ACTIONS(40),
-    [anon_sym_COMMA] = ACTIONS(97),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [17] = {
-    [sym_field] = STATE(28),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(99),
-    [aux_sym_document_token1] = ACTIONS(99),
-    [anon_sym_COMMA] = ACTIONS(68),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [18] = {
-    [sym_field] = STATE(36),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(99),
-    [anon_sym_COMMA] = ACTIONS(101),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [19] = {
-    [sym_field] = STATE(36),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(19),
-    [anon_sym_COMMA] = ACTIONS(101),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [20] = {
-    [sym_field] = STATE(36),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(40),
-    [anon_sym_COMMA] = ACTIONS(101),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [21] = {
-    [sym_field] = STATE(14),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(64),
-    [anon_sym_COMMA] = ACTIONS(101),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [22] = {
-    [sym_field] = STATE(36),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(37),
-    [anon_sym_COMMA] = ACTIONS(103),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(105),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [23] = {
-    [sym_field] = STATE(28),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(37),
-    [anon_sym_COMMA] = ACTIONS(103),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(11),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [24] = {
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(107),
-    [aux_sym_document_token1] = ACTIONS(107),
-    [anon_sym_COMMA] = ACTIONS(109),
-    [sym_text] = ACTIONS(112),
-    [aux_sym_number_token1] = ACTIONS(112),
-    [aux_sym_number_token2] = ACTIONS(112),
-    [aux_sym_float_token1] = ACTIONS(112),
-    [aux_sym_float_token2] = ACTIONS(112),
-    [anon_sym_true] = ACTIONS(112),
-    [anon_sym_false] = ACTIONS(112),
-  },
-  [25] = {
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(107),
-    [anon_sym_COMMA] = ACTIONS(114),
-    [sym_text] = ACTIONS(112),
-    [aux_sym_number_token1] = ACTIONS(112),
-    [aux_sym_number_token2] = ACTIONS(112),
-    [aux_sym_float_token1] = ACTIONS(112),
-    [aux_sym_float_token2] = ACTIONS(112),
-    [anon_sym_true] = ACTIONS(112),
-    [anon_sym_false] = ACTIONS(112),
-  },
-  [26] = {
-    [ts_builtin_sym_end] = ACTIONS(117),
-    [aux_sym_document_token1] = ACTIONS(117),
-    [anon_sym_COMMA] = ACTIONS(119),
-    [sym_text] = ACTIONS(119),
-    [aux_sym_number_token1] = ACTIONS(119),
-    [aux_sym_number_token2] = ACTIONS(119),
-    [aux_sym_float_token1] = ACTIONS(119),
-    [aux_sym_float_token2] = ACTIONS(119),
-    [anon_sym_true] = ACTIONS(119),
-    [anon_sym_false] = ACTIONS(119),
-  },
-  [27] = {
-    [ts_builtin_sym_end] = ACTIONS(121),
-    [aux_sym_document_token1] = ACTIONS(121),
-    [anon_sym_COMMA] = ACTIONS(123),
-    [sym_text] = ACTIONS(123),
-    [aux_sym_number_token1] = ACTIONS(123),
-    [aux_sym_number_token2] = ACTIONS(123),
-    [aux_sym_float_token1] = ACTIONS(123),
-    [aux_sym_float_token2] = ACTIONS(123),
-    [anon_sym_true] = ACTIONS(123),
-    [anon_sym_false] = ACTIONS(123),
-  },
-  [28] = {
-    [ts_builtin_sym_end] = ACTIONS(23),
-    [aux_sym_document_token1] = ACTIONS(23),
-    [anon_sym_COMMA] = ACTIONS(125),
-    [sym_text] = ACTIONS(125),
-    [aux_sym_number_token1] = ACTIONS(125),
-    [aux_sym_number_token2] = ACTIONS(125),
-    [aux_sym_float_token1] = ACTIONS(125),
-    [aux_sym_float_token2] = ACTIONS(125),
-    [anon_sym_true] = ACTIONS(125),
-    [anon_sym_false] = ACTIONS(125),
-  },
-  [29] = {
-    [ts_builtin_sym_end] = ACTIONS(127),
-    [aux_sym_document_token1] = ACTIONS(127),
-    [anon_sym_COMMA] = ACTIONS(129),
-    [sym_text] = ACTIONS(129),
-    [aux_sym_number_token1] = ACTIONS(129),
-    [aux_sym_number_token2] = ACTIONS(129),
-    [aux_sym_float_token1] = ACTIONS(129),
-    [aux_sym_float_token2] = ACTIONS(129),
-    [anon_sym_true] = ACTIONS(129),
-    [anon_sym_false] = ACTIONS(129),
-  },
-  [30] = {
-    [ts_builtin_sym_end] = ACTIONS(131),
-    [aux_sym_document_token1] = ACTIONS(131),
-    [anon_sym_COMMA] = ACTIONS(133),
-    [sym_text] = ACTIONS(133),
-    [aux_sym_number_token1] = ACTIONS(133),
-    [aux_sym_number_token2] = ACTIONS(133),
-    [aux_sym_float_token1] = ACTIONS(133),
-    [aux_sym_float_token2] = ACTIONS(133),
-    [anon_sym_true] = ACTIONS(133),
-    [anon_sym_false] = ACTIONS(133),
+    [sym_field] = STATE(23),
+    [sym_number] = STATE(21),
+    [sym_float] = STATE(21),
+    [sym_boolean] = STATE(21),
+    [aux_sym_number_token1] = ACTIONS(29),
+    [aux_sym_number_token2] = ACTIONS(29),
+    [aux_sym_float_token1] = ACTIONS(31),
+    [aux_sym_float_token2] = ACTIONS(31),
+    [anon_sym_true] = ACTIONS(33),
+    [anon_sym_false] = ACTIONS(33),
+    [sym_text] = ACTIONS(35),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
   [0] = 2,
-    ACTIONS(117), 1,
-      aux_sym_document_token1,
-    ACTIONS(119), 8,
-      anon_sym_COMMA,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [14] = 2,
-    ACTIONS(121), 1,
-      aux_sym_document_token1,
-    ACTIONS(123), 8,
-      anon_sym_COMMA,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [28] = 2,
-    ACTIONS(127), 1,
-      aux_sym_document_token1,
-    ACTIONS(129), 8,
-      anon_sym_COMMA,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [42] = 2,
-    ACTIONS(44), 3,
+    ACTIONS(15), 1,
       ts_builtin_sym_end,
-      anon_sym_COMMA,
-      aux_sym_number_token2,
-    ACTIONS(135), 6,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [56] = 2,
-    ACTIONS(131), 1,
-      aux_sym_document_token1,
-    ACTIONS(133), 8,
-      anon_sym_COMMA,
-      sym_text,
+    ACTIONS(37), 7,
       aux_sym_number_token1,
       aux_sym_number_token2,
       aux_sym_float_token1,
       aux_sym_float_token2,
       anon_sym_true,
       anon_sym_false,
-  [70] = 2,
-    ACTIONS(23), 1,
-      aux_sym_document_token1,
-    ACTIONS(125), 8,
-      anon_sym_COMMA,
       sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [84] = 4,
-    ACTIONS(107), 1,
-      aux_sym_number_token2,
-    ACTIONS(137), 1,
+  [13] = 3,
+    ACTIONS(41), 1,
       anon_sym_COMMA,
-    STATE(37), 1,
+    STATE(8), 1,
       aux_sym_row_repeat1,
-    ACTIONS(112), 6,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [102] = 2,
-    ACTIONS(17), 1,
+    ACTIONS(39), 2,
       ts_builtin_sym_end,
-    ACTIONS(140), 1,
       aux_sym_document_token1,
-  [109] = 2,
-    ACTIONS(140), 1,
-      aux_sym_document_token1,
-    ACTIONS(142), 1,
+  [24] = 3,
+    ACTIONS(41), 1,
+      anon_sym_COMMA,
+    STATE(9), 1,
+      aux_sym_row_repeat1,
+    ACTIONS(43), 2,
       ts_builtin_sym_end,
-  [116] = 1,
-    ACTIONS(140), 1,
       aux_sym_document_token1,
-  [120] = 1,
-    ACTIONS(144), 1,
+  [35] = 3,
+    ACTIONS(47), 1,
+      anon_sym_COMMA,
+    STATE(9), 1,
+      aux_sym_row_repeat1,
+    ACTIONS(45), 2,
+      ts_builtin_sym_end,
+      aux_sym_document_token1,
+  [46] = 3,
+    ACTIONS(39), 1,
+      aux_sym_document_token1,
+    ACTIONS(50), 1,
+      anon_sym_COMMA,
+    STATE(16), 1,
+      aux_sym_row_repeat1,
+  [56] = 2,
+    ACTIONS(54), 1,
+      anon_sym_COMMA,
+    ACTIONS(52), 2,
+      ts_builtin_sym_end,
+      aux_sym_document_token1,
+  [64] = 2,
+    ACTIONS(58), 1,
+      anon_sym_COMMA,
+    ACTIONS(56), 2,
+      ts_builtin_sym_end,
+      aux_sym_document_token1,
+  [72] = 2,
+    ACTIONS(62), 1,
+      anon_sym_COMMA,
+    ACTIONS(60), 2,
+      ts_builtin_sym_end,
+      aux_sym_document_token1,
+  [80] = 2,
+    ACTIONS(66), 1,
+      anon_sym_COMMA,
+    ACTIONS(64), 2,
+      ts_builtin_sym_end,
+      aux_sym_document_token1,
+  [88] = 3,
+    ACTIONS(45), 1,
+      aux_sym_document_token1,
+    ACTIONS(68), 1,
+      anon_sym_COMMA,
+    STATE(15), 1,
+      aux_sym_row_repeat1,
+  [98] = 3,
+    ACTIONS(43), 1,
+      aux_sym_document_token1,
+    ACTIONS(50), 1,
+      anon_sym_COMMA,
+    STATE(15), 1,
+      aux_sym_row_repeat1,
+  [108] = 2,
+    ACTIONS(71), 1,
+      anon_sym_COMMA,
+    ACTIONS(45), 2,
+      ts_builtin_sym_end,
+      aux_sym_document_token1,
+  [116] = 2,
+    ACTIONS(52), 1,
+      aux_sym_document_token1,
+    ACTIONS(54), 1,
+      anon_sym_COMMA,
+  [123] = 2,
+    ACTIONS(56), 1,
+      aux_sym_document_token1,
+    ACTIONS(58), 1,
+      anon_sym_COMMA,
+  [130] = 2,
+    ACTIONS(60), 1,
+      aux_sym_document_token1,
+    ACTIONS(62), 1,
+      anon_sym_COMMA,
+  [137] = 2,
+    ACTIONS(64), 1,
+      aux_sym_document_token1,
+    ACTIONS(66), 1,
+      anon_sym_COMMA,
+  [144] = 2,
+    ACTIONS(73), 1,
+      ts_builtin_sym_end,
+    ACTIONS(75), 1,
+      aux_sym_document_token1,
+  [151] = 2,
+    ACTIONS(45), 1,
+      aux_sym_document_token1,
+    ACTIONS(71), 1,
+      anon_sym_COMMA,
+  [158] = 2,
+    ACTIONS(13), 1,
+      ts_builtin_sym_end,
+    ACTIONS(75), 1,
+      aux_sym_document_token1,
+  [165] = 1,
+    ACTIONS(75), 1,
+      aux_sym_document_token1,
+  [169] = 1,
+    ACTIONS(77), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(31)] = 0,
-  [SMALL_STATE(32)] = 14,
-  [SMALL_STATE(33)] = 28,
-  [SMALL_STATE(34)] = 42,
-  [SMALL_STATE(35)] = 56,
-  [SMALL_STATE(36)] = 70,
-  [SMALL_STATE(37)] = 84,
-  [SMALL_STATE(38)] = 102,
-  [SMALL_STATE(39)] = 109,
-  [SMALL_STATE(40)] = 116,
-  [SMALL_STATE(41)] = 120,
+  [SMALL_STATE(6)] = 0,
+  [SMALL_STATE(7)] = 13,
+  [SMALL_STATE(8)] = 24,
+  [SMALL_STATE(9)] = 35,
+  [SMALL_STATE(10)] = 46,
+  [SMALL_STATE(11)] = 56,
+  [SMALL_STATE(12)] = 64,
+  [SMALL_STATE(13)] = 72,
+  [SMALL_STATE(14)] = 80,
+  [SMALL_STATE(15)] = 88,
+  [SMALL_STATE(16)] = 98,
+  [SMALL_STATE(17)] = 108,
+  [SMALL_STATE(18)] = 116,
+  [SMALL_STATE(19)] = 123,
+  [SMALL_STATE(20)] = 130,
+  [SMALL_STATE(21)] = 137,
+  [SMALL_STATE(22)] = 144,
+  [SMALL_STATE(23)] = 151,
+  [SMALL_STATE(24)] = 158,
+  [SMALL_STATE(25)] = 165,
+  [SMALL_STATE(26)] = 169,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
-  [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 3, 0, 0),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [23] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0),
-  [25] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(23),
-  [28] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(30),
-  [31] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(26),
-  [34] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(27),
-  [37] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(29),
-  [40] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 2, 0, 0),
-  [42] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
-  [44] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
-  [49] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(35),
-  [52] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(31),
-  [55] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(31),
-  [58] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(32),
-  [61] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(33),
-  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 1, 0, 0),
-  [66] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
-  [68] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
-  [70] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
-  [72] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
-  [74] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
-  [76] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [78] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [80] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [82] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(22),
-  [85] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(35),
-  [88] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(31),
-  [91] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(32),
-  [94] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(33),
-  [97] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
-  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 4, 0, 0),
-  [101] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0),
-  [109] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0), SHIFT_REPEAT(24),
-  [112] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0),
-  [114] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0), SHIFT_REPEAT(25),
-  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_number, 1, 0, 0),
-  [119] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_number, 1, 0, 0),
-  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1, 0, 0),
-  [123] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1, 0, 0),
-  [125] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0),
-  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean, 1, 0, 0),
-  [129] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_boolean, 1, 0, 0),
-  [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_field, 1, 0, 0),
-  [133] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_field, 1, 0, 0),
-  [135] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [137] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0), SHIFT_REPEAT(37),
-  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 0),
-  [144] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
+  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1),
+  [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
+  [17] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(18),
+  [20] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(19),
+  [23] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(20),
+  [26] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(21),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
+  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
+  [37] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2),
+  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 1),
+  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
+  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 2),
+  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_row_repeat1, 2),
+  [47] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2), SHIFT_REPEAT(4),
+  [50] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
+  [52] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_number, 1),
+  [54] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_number, 1),
+  [56] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1),
+  [58] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1),
+  [60] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean, 1),
+  [62] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_boolean, 1),
+  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_field, 1),
+  [66] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_field, 1),
+  [68] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2), SHIFT_REPEAT(5),
+  [71] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2),
+  [73] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2),
+  [75] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [77] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
 };
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-#ifdef TREE_SITTER_HIDE_SYMBOLS
-#define TS_PUBLIC
-#elif defined(_WIN32)
-#define TS_PUBLIC __declspec(dllexport)
-#else
-#define TS_PUBLIC __attribute__((visibility("default")))
+#ifdef _WIN32
+#define extern __declspec(dllexport)
 #endif
 
-TS_PUBLIC const TSLanguage *tree_sitter_csv(void) {
+extern const TSLanguage *tree_sitter_csv(void) {
   static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,

--- a/csv/src/tree_sitter/parser.h
+++ b/csv/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -86,11 +87,6 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
-typedef struct {
-  int32_t start;
-  int32_t end;
-} TSCharacterRange;
-
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -130,38 +126,13 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
-  uint32_t index = 0;
-  uint32_t size = len - index;
-  while (size > 1) {
-    uint32_t half_size = size / 2;
-    uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
-    if (lookahead >= range->start && lookahead <= range->end) {
-      return true;
-    } else if (lookahead > range->end) {
-      index = mid_index;
-    }
-    size -= half_size;
-  }
-  TSCharacterRange *range = &ranges[index];
-  return (lookahead >= range->start && lookahead <= range->end);
-}
-
 /*
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -175,17 +146,6 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {                          \
     state = state_value;     \
     goto next_state;         \
-  }
-
-#define ADVANCE_MAP(...)                                              \
-  {                                                                   \
-    static const uint16_t map[] = { __VA_ARGS__ };                    \
-    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
-      if (map[i] == lookahead) {                                      \
-        state = map[i + 1];                                           \
-        goto next_state;                                              \
-      }                                                               \
-    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -206,7 +166,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -216,7 +176,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -224,7 +184,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}
@@ -237,15 +197,14 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }                                 \
   }}
 
-#define REDUCE(symbol_name, children, precedence, prod_id) \
-  {{                                                       \
-    .reduce = {                                            \
-      .type = TSParseActionTypeReduce,                     \
-      .symbol = symbol_name,                               \
-      .child_count = children,                             \
-      .dynamic_precedence = precedence,                    \
-      .production_id = prod_id                             \
-    },                                                     \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
   }}
 
 #define RECOVER()                    \

--- a/psv/src/grammar.json
+++ b/psv/src/grammar.json
@@ -35,55 +35,26 @@
       ]
     },
     "row": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "STRING",
-                "value": "|"
-              }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "field"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "STRING",
-                      "value": "|"
-                    }
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "field"
-                  }
-                ]
-              }
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "STRING",
-                "value": "|"
-              }
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "field"
         },
         {
-          "type": "REPEAT1",
+          "type": "REPEAT",
           "content": {
-            "type": "STRING",
-            "value": "|"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "|"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "field"
+              }
+            ]
           }
         }
       ]
@@ -108,47 +79,6 @@
           "name": "boolean"
         }
       ]
-    },
-    "text": {
-      "type": "TOKEN",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "PATTERN",
-            "value": "[^|\\d\\s\"][^| \\n\\r\"]+"
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "\""
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "[^\"]"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "\"\""
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "STRING",
-                "value": "\""
-              }
-            ]
-          }
-        ]
-      }
     },
     "number": {
       "type": "CHOICE",
@@ -188,6 +118,47 @@
           "value": "false"
         }
       ]
+    },
+    "text": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "PATTERN",
+            "value": "[^|\\r\\n]*"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\""
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "PATTERN",
+                      "value": "[^\"]"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "\"\""
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "STRING",
+                "value": "\""
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   "extras": [
@@ -202,3 +173,4 @@
   "inline": [],
   "supertypes": []
 }
+

--- a/psv/src/node-types.json
+++ b/psv/src/node-types.json
@@ -62,7 +62,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "field",

--- a/psv/src/parser.c
+++ b/psv/src/parser.c
@@ -1,30 +1,31 @@
-#include "tree_sitter/parser.h"
+#include <tree_sitter/parser.h>
 
 #if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 42
-#define LARGE_STATE_COUNT 31
-#define SYMBOL_COUNT 19
+#define STATE_COUNT 27
+#define LARGE_STATE_COUNT 6
+#define SYMBOL_COUNT 18
 #define ALIAS_COUNT 0
 #define TOKEN_COUNT 10
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 0
-#define MAX_ALIAS_SEQUENCE_LENGTH 4
+#define MAX_ALIAS_SEQUENCE_LENGTH 2
 #define PRODUCTION_ID_COUNT 1
 
-enum ts_symbol_identifiers {
+enum {
   aux_sym_document_token1 = 1,
   anon_sym_PIPE = 2,
-  sym_text = 3,
-  aux_sym_number_token1 = 4,
-  aux_sym_number_token2 = 5,
-  aux_sym_float_token1 = 6,
-  aux_sym_float_token2 = 7,
-  anon_sym_true = 8,
-  anon_sym_false = 9,
+  aux_sym_number_token1 = 3,
+  aux_sym_number_token2 = 4,
+  aux_sym_float_token1 = 5,
+  aux_sym_float_token2 = 6,
+  anon_sym_true = 7,
+  anon_sym_false = 8,
+  sym_text = 9,
   sym_document = 10,
   sym_row = 11,
   sym_field = 12,
@@ -33,20 +34,19 @@ enum ts_symbol_identifiers {
   sym_boolean = 15,
   aux_sym_document_repeat1 = 16,
   aux_sym_row_repeat1 = 17,
-  aux_sym_row_repeat2 = 18,
 };
 
 static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
   [aux_sym_document_token1] = "document_token1",
   [anon_sym_PIPE] = "|",
-  [sym_text] = "text",
   [aux_sym_number_token1] = "number_token1",
   [aux_sym_number_token2] = "number_token2",
   [aux_sym_float_token1] = "float_token1",
   [aux_sym_float_token2] = "float_token2",
   [anon_sym_true] = "true",
   [anon_sym_false] = "false",
+  [sym_text] = "text",
   [sym_document] = "document",
   [sym_row] = "row",
   [sym_field] = "field",
@@ -55,20 +55,19 @@ static const char * const ts_symbol_names[] = {
   [sym_boolean] = "boolean",
   [aux_sym_document_repeat1] = "document_repeat1",
   [aux_sym_row_repeat1] = "row_repeat1",
-  [aux_sym_row_repeat2] = "row_repeat2",
 };
 
 static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
   [aux_sym_document_token1] = aux_sym_document_token1,
   [anon_sym_PIPE] = anon_sym_PIPE,
-  [sym_text] = sym_text,
   [aux_sym_number_token1] = aux_sym_number_token1,
   [aux_sym_number_token2] = aux_sym_number_token2,
   [aux_sym_float_token1] = aux_sym_float_token1,
   [aux_sym_float_token2] = aux_sym_float_token2,
   [anon_sym_true] = anon_sym_true,
   [anon_sym_false] = anon_sym_false,
+  [sym_text] = sym_text,
   [sym_document] = sym_document,
   [sym_row] = sym_row,
   [sym_field] = sym_field,
@@ -77,7 +76,6 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_boolean] = sym_boolean,
   [aux_sym_document_repeat1] = aux_sym_document_repeat1,
   [aux_sym_row_repeat1] = aux_sym_row_repeat1,
-  [aux_sym_row_repeat2] = aux_sym_row_repeat2,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -92,10 +90,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [anon_sym_PIPE] = {
     .visible = true,
     .named = false,
-  },
-  [sym_text] = {
-    .visible = true,
-    .named = true,
   },
   [aux_sym_number_token1] = {
     .visible = false,
@@ -120,6 +114,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [anon_sym_false] = {
     .visible = true,
     .named = false,
+  },
+  [sym_text] = {
+    .visible = true,
+    .named = true,
   },
   [sym_document] = {
     .visible = true,
@@ -153,10 +151,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_row_repeat2] = {
-    .visible = false,
-    .named = false,
-  },
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
@@ -173,43 +167,28 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [2] = 2,
   [3] = 3,
   [4] = 4,
-  [5] = 5,
+  [5] = 4,
   [6] = 6,
   [7] = 7,
   [8] = 8,
   [9] = 9,
-  [10] = 8,
+  [10] = 7,
   [11] = 11,
-  [12] = 3,
-  [13] = 4,
-  [14] = 5,
-  [15] = 15,
-  [16] = 7,
+  [12] = 12,
+  [13] = 13,
+  [14] = 14,
+  [15] = 9,
+  [16] = 8,
   [17] = 17,
-  [18] = 17,
-  [19] = 15,
-  [20] = 11,
-  [21] = 9,
+  [18] = 11,
+  [19] = 12,
+  [20] = 13,
+  [21] = 14,
   [22] = 22,
-  [23] = 22,
+  [23] = 17,
   [24] = 24,
-  [25] = 24,
+  [25] = 25,
   [26] = 26,
-  [27] = 27,
-  [28] = 28,
-  [29] = 29,
-  [30] = 30,
-  [31] = 26,
-  [32] = 27,
-  [33] = 29,
-  [34] = 34,
-  [35] = 30,
-  [36] = 28,
-  [37] = 24,
-  [38] = 38,
-  [39] = 39,
-  [40] = 40,
-  [41] = 41,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -217,206 +196,293 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(8);
-      ADVANCE_MAP(
-        '\n', 9,
-        '\r', 9,
-        '"', 1,
-        '.', 4,
-        '0', 19,
-        'f', 2,
-        't', 3,
-        '|', 10,
-      );
-      if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') SKIP(0);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(20);
-      if (lookahead != 0) ADVANCE(6);
+      if (eof) ADVANCE(12);
+      if (lookahead == '.') ADVANCE(9);
+      if (lookahead == '0') ADVANCE(15);
+      if (lookahead == 'f') ADVANCE(2);
+      if (lookahead == 't') ADVANCE(6);
+      if (lookahead == '|') ADVANCE(14);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(0)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(16);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(11);
+      if (lookahead == '"') ADVANCE(32);
       if (lookahead != 0) ADVANCE(1);
       END_STATE();
     case 2:
-      if (lookahead == 'a') ADVANCE(14);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
+      if (lookahead == 'a') ADVANCE(5);
       END_STATE();
     case 3:
-      if (lookahead == 'r') ADVANCE(16);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
+      if (lookahead == 'e') ADVANCE(25);
       END_STATE();
     case 4:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(17);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
+      if (lookahead == 'e') ADVANCE(27);
       END_STATE();
     case 5:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(21);
+      if (lookahead == 'l') ADVANCE(7);
       END_STATE();
     case 6:
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
+      if (lookahead == 'r') ADVANCE(8);
       END_STATE();
     case 7:
-      if (eof) ADVANCE(8);
-      if (lookahead == '"') ADVANCE(1);
-      if (lookahead == '.') ADVANCE(4);
-      if (lookahead == '0') ADVANCE(19);
-      if (lookahead == 'f') ADVANCE(2);
-      if (lookahead == 't') ADVANCE(3);
-      if (lookahead == '|') ADVANCE(10);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(7);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(20);
-      if (lookahead != 0) ADVANCE(6);
+      if (lookahead == 's') ADVANCE(4);
       END_STATE();
     case 8:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (lookahead == 'u') ADVANCE(3);
       END_STATE();
     case 9:
-      ACCEPT_TOKEN(aux_sym_document_token1);
-      if (lookahead == '\n') ADVANCE(9);
-      if (lookahead == '\r') ADVANCE(9);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(21);
       END_STATE();
     case 10:
-      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(19);
       END_STATE();
     case 11:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == '"') ADVANCE(1);
+      if (eof) ADVANCE(12);
+      if (lookahead == '\n') ADVANCE(13);
+      if (lookahead == '\r') ADVANCE(13);
+      if (lookahead == '|') ADVANCE(14);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(11)
       END_STATE();
     case 12:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e') ADVANCE(24);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 13:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e') ADVANCE(25);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
+      ACCEPT_TOKEN(aux_sym_document_token1);
+      if (lookahead == '\n') ADVANCE(13);
+      if (lookahead == '\r') ADVANCE(13);
       END_STATE();
     case 14:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l') ADVANCE(15);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
+      ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
     case 15:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 's') ADVANCE(13);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
-      END_STATE();
-    case 16:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'u') ADVANCE(12);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
-      END_STATE();
-    case 17:
-      ACCEPT_TOKEN(sym_text);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(17);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
-      END_STATE();
-    case 18:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
-      END_STATE();
-    case 19:
       ACCEPT_TOKEN(aux_sym_number_token1);
       if (lookahead == '.') ADVANCE(23);
       if (lookahead == 'X' ||
-          lookahead == 'x') ADVANCE(5);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(20);
+          lookahead == 'x') ADVANCE(10);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(16);
       END_STATE();
-    case 20:
+    case 16:
       ACCEPT_TOKEN(aux_sym_number_token1);
       if (lookahead == '.') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(20);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(16);
       END_STATE();
-    case 21:
+    case 17:
+      ACCEPT_TOKEN(aux_sym_number_token1);
+      if (lookahead == '.') ADVANCE(24);
+      if (lookahead == 'X' ||
+          lookahead == 'x') ADVANCE(41);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(18);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 18:
+      ACCEPT_TOKEN(aux_sym_number_token1);
+      if (lookahead == '.') ADVANCE(24);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(18);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 19:
       ACCEPT_TOKEN(aux_sym_number_token2);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(21);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(19);
+      END_STATE();
+    case 20:
+      ACCEPT_TOKEN(aux_sym_number_token2);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(20);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 21:
+      ACCEPT_TOKEN(aux_sym_float_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(21);
       END_STATE();
     case 22:
       ACCEPT_TOKEN(aux_sym_float_token1);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(22);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
       END_STATE();
     case 23:
       ACCEPT_TOKEN(aux_sym_float_token2);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(22);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(21);
       END_STATE();
     case 24:
+      ACCEPT_TOKEN(aux_sym_float_token2);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(22);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 25:
+      ACCEPT_TOKEN(anon_sym_true);
+      END_STATE();
+    case 26:
       ACCEPT_TOKEN(anon_sym_true);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
+          lookahead != '|') ADVANCE(42);
       END_STATE();
-    case 25:
+    case 27:
+      ACCEPT_TOKEN(anon_sym_false);
+      END_STATE();
+    case 28:
       ACCEPT_TOKEN(anon_sym_false);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"' &&
-          lookahead != '|') ADVANCE(18);
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 29:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '"') ADVANCE(31);
+      if (lookahead == '.') ADVANCE(40);
+      if (lookahead == '0') ADVANCE(17);
+      if (lookahead == 'f') ADVANCE(33);
+      if (lookahead == 't') ADVANCE(37);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(29);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(18);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 30:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '"') ADVANCE(31);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 31:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '"') ADVANCE(30);
+      if (lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == '|') ADVANCE(1);
+      if (lookahead != 0) ADVANCE(31);
+      END_STATE();
+    case 32:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '"') ADVANCE(1);
+      END_STATE();
+    case 33:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'a') ADVANCE(36);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 34:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'e') ADVANCE(26);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 35:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'e') ADVANCE(28);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 36:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'l') ADVANCE(38);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 37:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'r') ADVANCE(39);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 38:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 's') ADVANCE(35);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 39:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'u') ADVANCE(34);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 40:
+      ACCEPT_TOKEN(sym_text);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(22);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 41:
+      ACCEPT_TOKEN(sym_text);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(20);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 42:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
+      END_STATE();
+    case 43:
+      ACCEPT_TOKEN(sym_text);
+      if (eof) ADVANCE(12);
+      if (lookahead == '"') ADVANCE(31);
+      if (lookahead == '.') ADVANCE(40);
+      if (lookahead == '0') ADVANCE(17);
+      if (lookahead == 'f') ADVANCE(33);
+      if (lookahead == 't') ADVANCE(37);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(29);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(18);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != '|') ADVANCE(42);
       END_STATE();
     default:
       return false;
@@ -425,55 +491,38 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 7},
-  [2] = {.lex_state = 7},
-  [3] = {.lex_state = 0},
-  [4] = {.lex_state = 0},
-  [5] = {.lex_state = 0},
-  [6] = {.lex_state = 7},
-  [7] = {.lex_state = 0},
-  [8] = {.lex_state = 0},
-  [9] = {.lex_state = 0},
-  [10] = {.lex_state = 0},
-  [11] = {.lex_state = 0},
-  [12] = {.lex_state = 0},
-  [13] = {.lex_state = 0},
-  [14] = {.lex_state = 0},
-  [15] = {.lex_state = 0},
-  [16] = {.lex_state = 0},
-  [17] = {.lex_state = 0},
-  [18] = {.lex_state = 0},
-  [19] = {.lex_state = 0},
-  [20] = {.lex_state = 0},
-  [21] = {.lex_state = 0},
-  [22] = {.lex_state = 7},
-  [23] = {.lex_state = 7},
-  [24] = {.lex_state = 0},
-  [25] = {.lex_state = 0},
+  [1] = {.lex_state = 43},
+  [2] = {.lex_state = 43},
+  [3] = {.lex_state = 43},
+  [4] = {.lex_state = 43},
+  [5] = {.lex_state = 43},
+  [6] = {.lex_state = 43},
+  [7] = {.lex_state = 11},
+  [8] = {.lex_state = 11},
+  [9] = {.lex_state = 11},
+  [10] = {.lex_state = 11},
+  [11] = {.lex_state = 11},
+  [12] = {.lex_state = 11},
+  [13] = {.lex_state = 11},
+  [14] = {.lex_state = 11},
+  [15] = {.lex_state = 11},
+  [16] = {.lex_state = 11},
+  [17] = {.lex_state = 11},
+  [18] = {.lex_state = 11},
+  [19] = {.lex_state = 11},
+  [20] = {.lex_state = 11},
+  [21] = {.lex_state = 11},
+  [22] = {.lex_state = 11},
+  [23] = {.lex_state = 11},
+  [24] = {.lex_state = 11},
+  [25] = {.lex_state = 11},
   [26] = {.lex_state = 0},
-  [27] = {.lex_state = 0},
-  [28] = {.lex_state = 0},
-  [29] = {.lex_state = 0},
-  [30] = {.lex_state = 0},
-  [31] = {.lex_state = 0},
-  [32] = {.lex_state = 0},
-  [33] = {.lex_state = 0},
-  [34] = {.lex_state = 7},
-  [35] = {.lex_state = 0},
-  [36] = {.lex_state = 0},
-  [37] = {.lex_state = 7},
-  [38] = {.lex_state = 0},
-  [39] = {.lex_state = 0},
-  [40] = {.lex_state = 0},
-  [41] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
-    [aux_sym_document_token1] = ACTIONS(1),
     [anon_sym_PIPE] = ACTIONS(1),
-    [sym_text] = ACTIONS(1),
     [aux_sym_number_token1] = ACTIONS(1),
     [aux_sym_number_token2] = ACTIONS(1),
     [aux_sym_float_token1] = ACTIONS(1),
@@ -482,682 +531,284 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_false] = ACTIONS(1),
   },
   [1] = {
-    [sym_document] = STATE(41),
-    [sym_row] = STATE(38),
-    [sym_field] = STATE(8),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
+    [sym_document] = STATE(26),
+    [sym_row] = STATE(24),
+    [sym_field] = STATE(7),
+    [sym_number] = STATE(14),
+    [sym_float] = STATE(14),
+    [sym_boolean] = STATE(14),
     [aux_sym_document_repeat1] = STATE(2),
-    [aux_sym_row_repeat1] = STATE(9),
     [ts_builtin_sym_end] = ACTIONS(3),
-    [anon_sym_PIPE] = ACTIONS(5),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(11),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
+    [aux_sym_number_token1] = ACTIONS(5),
+    [aux_sym_number_token2] = ACTIONS(5),
+    [aux_sym_float_token1] = ACTIONS(7),
+    [aux_sym_float_token2] = ACTIONS(7),
+    [anon_sym_true] = ACTIONS(9),
+    [anon_sym_false] = ACTIONS(9),
+    [sym_text] = ACTIONS(11),
   },
   [2] = {
-    [sym_row] = STATE(39),
-    [sym_field] = STATE(8),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_document_repeat1] = STATE(6),
-    [aux_sym_row_repeat1] = STATE(9),
-    [ts_builtin_sym_end] = ACTIONS(17),
-    [anon_sym_PIPE] = ACTIONS(5),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(11),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
+    [sym_row] = STATE(22),
+    [sym_field] = STATE(7),
+    [sym_number] = STATE(14),
+    [sym_float] = STATE(14),
+    [sym_boolean] = STATE(14),
+    [aux_sym_document_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(13),
+    [aux_sym_number_token1] = ACTIONS(5),
+    [aux_sym_number_token2] = ACTIONS(5),
+    [aux_sym_float_token1] = ACTIONS(7),
+    [aux_sym_float_token2] = ACTIONS(7),
+    [anon_sym_true] = ACTIONS(9),
+    [anon_sym_false] = ACTIONS(9),
+    [sym_text] = ACTIONS(11),
   },
   [3] = {
-    [sym_field] = STATE(4),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(17),
-    [aux_sym_row_repeat2] = STATE(4),
-    [ts_builtin_sym_end] = ACTIONS(19),
-    [aux_sym_document_token1] = ACTIONS(19),
-    [anon_sym_PIPE] = ACTIONS(21),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
+    [sym_row] = STATE(25),
+    [sym_field] = STATE(10),
+    [sym_number] = STATE(21),
+    [sym_float] = STATE(21),
+    [sym_boolean] = STATE(21),
+    [aux_sym_document_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(15),
+    [aux_sym_number_token1] = ACTIONS(17),
+    [aux_sym_number_token2] = ACTIONS(17),
+    [aux_sym_float_token1] = ACTIONS(20),
+    [aux_sym_float_token2] = ACTIONS(20),
+    [anon_sym_true] = ACTIONS(23),
+    [anon_sym_false] = ACTIONS(23),
+    [sym_text] = ACTIONS(26),
   },
   [4] = {
-    [sym_field] = STATE(4),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(23),
-    [aux_sym_row_repeat2] = STATE(4),
-    [ts_builtin_sym_end] = ACTIONS(23),
-    [aux_sym_document_token1] = ACTIONS(23),
-    [anon_sym_PIPE] = ACTIONS(25),
-    [sym_text] = ACTIONS(28),
-    [aux_sym_number_token1] = ACTIONS(31),
-    [aux_sym_number_token2] = ACTIONS(31),
-    [aux_sym_float_token1] = ACTIONS(34),
-    [aux_sym_float_token2] = ACTIONS(34),
-    [anon_sym_true] = ACTIONS(37),
-    [anon_sym_false] = ACTIONS(37),
+    [sym_field] = STATE(17),
+    [sym_number] = STATE(14),
+    [sym_float] = STATE(14),
+    [sym_boolean] = STATE(14),
+    [aux_sym_number_token1] = ACTIONS(5),
+    [aux_sym_number_token2] = ACTIONS(5),
+    [aux_sym_float_token1] = ACTIONS(7),
+    [aux_sym_float_token2] = ACTIONS(7),
+    [anon_sym_true] = ACTIONS(9),
+    [anon_sym_false] = ACTIONS(9),
+    [sym_text] = ACTIONS(11),
   },
   [5] = {
-    [sym_field] = STATE(3),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(15),
-    [aux_sym_row_repeat2] = STATE(3),
-    [ts_builtin_sym_end] = ACTIONS(40),
-    [aux_sym_document_token1] = ACTIONS(40),
-    [anon_sym_PIPE] = ACTIONS(42),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [6] = {
-    [sym_row] = STATE(40),
-    [sym_field] = STATE(10),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_document_repeat1] = STATE(6),
-    [aux_sym_row_repeat1] = STATE(21),
-    [ts_builtin_sym_end] = ACTIONS(44),
-    [anon_sym_PIPE] = ACTIONS(46),
-    [sym_text] = ACTIONS(49),
-    [aux_sym_number_token1] = ACTIONS(52),
-    [aux_sym_number_token2] = ACTIONS(55),
-    [aux_sym_float_token1] = ACTIONS(58),
-    [aux_sym_float_token2] = ACTIONS(58),
-    [anon_sym_true] = ACTIONS(61),
-    [anon_sym_false] = ACTIONS(61),
-  },
-  [7] = {
-    [sym_field] = STATE(4),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(15),
-    [aux_sym_row_repeat2] = STATE(4),
-    [ts_builtin_sym_end] = ACTIONS(40),
-    [aux_sym_document_token1] = ACTIONS(40),
-    [anon_sym_PIPE] = ACTIONS(42),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [8] = {
-    [sym_field] = STATE(7),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(11),
-    [aux_sym_row_repeat2] = STATE(7),
-    [ts_builtin_sym_end] = ACTIONS(64),
-    [aux_sym_document_token1] = ACTIONS(64),
-    [anon_sym_PIPE] = ACTIONS(66),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [9] = {
-    [sym_field] = STATE(5),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(64),
-    [aux_sym_document_token1] = ACTIONS(64),
-    [anon_sym_PIPE] = ACTIONS(68),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [10] = {
-    [sym_field] = STATE(16),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(20),
-    [aux_sym_row_repeat2] = STATE(16),
-    [aux_sym_document_token1] = ACTIONS(64),
-    [anon_sym_PIPE] = ACTIONS(70),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [11] = {
-    [sym_field] = STATE(28),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(40),
-    [aux_sym_document_token1] = ACTIONS(40),
-    [anon_sym_PIPE] = ACTIONS(68),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [12] = {
-    [sym_field] = STATE(13),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(18),
-    [aux_sym_row_repeat2] = STATE(13),
-    [aux_sym_document_token1] = ACTIONS(19),
-    [anon_sym_PIPE] = ACTIONS(80),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [13] = {
-    [sym_field] = STATE(13),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(22),
-    [aux_sym_row_repeat2] = STATE(13),
-    [aux_sym_document_token1] = ACTIONS(23),
-    [anon_sym_PIPE] = ACTIONS(82),
-    [sym_text] = ACTIONS(85),
-    [aux_sym_number_token1] = ACTIONS(88),
-    [aux_sym_number_token2] = ACTIONS(88),
-    [aux_sym_float_token1] = ACTIONS(91),
-    [aux_sym_float_token2] = ACTIONS(91),
-    [anon_sym_true] = ACTIONS(94),
-    [anon_sym_false] = ACTIONS(94),
-  },
-  [14] = {
-    [sym_field] = STATE(12),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(19),
-    [aux_sym_row_repeat2] = STATE(12),
-    [aux_sym_document_token1] = ACTIONS(40),
-    [anon_sym_PIPE] = ACTIONS(97),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [15] = {
-    [sym_field] = STATE(28),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(19),
-    [aux_sym_document_token1] = ACTIONS(19),
-    [anon_sym_PIPE] = ACTIONS(68),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [16] = {
-    [sym_field] = STATE(13),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(19),
-    [aux_sym_row_repeat2] = STATE(13),
-    [aux_sym_document_token1] = ACTIONS(40),
-    [anon_sym_PIPE] = ACTIONS(97),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [17] = {
-    [sym_field] = STATE(28),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(99),
-    [aux_sym_document_token1] = ACTIONS(99),
-    [anon_sym_PIPE] = ACTIONS(68),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [18] = {
-    [sym_field] = STATE(36),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(99),
-    [anon_sym_PIPE] = ACTIONS(101),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [19] = {
-    [sym_field] = STATE(36),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(19),
-    [anon_sym_PIPE] = ACTIONS(101),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [20] = {
-    [sym_field] = STATE(36),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(40),
-    [anon_sym_PIPE] = ACTIONS(101),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [21] = {
-    [sym_field] = STATE(14),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(64),
-    [anon_sym_PIPE] = ACTIONS(101),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(74),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [22] = {
-    [sym_field] = STATE(36),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(37),
-    [anon_sym_PIPE] = ACTIONS(103),
-    [sym_text] = ACTIONS(72),
-    [aux_sym_number_token1] = ACTIONS(74),
-    [aux_sym_number_token2] = ACTIONS(105),
-    [aux_sym_float_token1] = ACTIONS(76),
-    [aux_sym_float_token2] = ACTIONS(76),
-    [anon_sym_true] = ACTIONS(78),
-    [anon_sym_false] = ACTIONS(78),
-  },
-  [23] = {
-    [sym_field] = STATE(28),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(37),
-    [anon_sym_PIPE] = ACTIONS(103),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(11),
-    [aux_sym_float_token1] = ACTIONS(13),
-    [aux_sym_float_token2] = ACTIONS(13),
-    [anon_sym_true] = ACTIONS(15),
-    [anon_sym_false] = ACTIONS(15),
-  },
-  [24] = {
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(107),
-    [aux_sym_document_token1] = ACTIONS(107),
-    [anon_sym_PIPE] = ACTIONS(109),
-    [sym_text] = ACTIONS(112),
-    [aux_sym_number_token1] = ACTIONS(112),
-    [aux_sym_number_token2] = ACTIONS(112),
-    [aux_sym_float_token1] = ACTIONS(112),
-    [aux_sym_float_token2] = ACTIONS(112),
-    [anon_sym_true] = ACTIONS(112),
-    [anon_sym_false] = ACTIONS(112),
-  },
-  [25] = {
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(107),
-    [anon_sym_PIPE] = ACTIONS(114),
-    [sym_text] = ACTIONS(112),
-    [aux_sym_number_token1] = ACTIONS(112),
-    [aux_sym_number_token2] = ACTIONS(112),
-    [aux_sym_float_token1] = ACTIONS(112),
-    [aux_sym_float_token2] = ACTIONS(112),
-    [anon_sym_true] = ACTIONS(112),
-    [anon_sym_false] = ACTIONS(112),
-  },
-  [26] = {
-    [ts_builtin_sym_end] = ACTIONS(117),
-    [aux_sym_document_token1] = ACTIONS(117),
-    [anon_sym_PIPE] = ACTIONS(119),
-    [sym_text] = ACTIONS(119),
-    [aux_sym_number_token1] = ACTIONS(119),
-    [aux_sym_number_token2] = ACTIONS(119),
-    [aux_sym_float_token1] = ACTIONS(119),
-    [aux_sym_float_token2] = ACTIONS(119),
-    [anon_sym_true] = ACTIONS(119),
-    [anon_sym_false] = ACTIONS(119),
-  },
-  [27] = {
-    [ts_builtin_sym_end] = ACTIONS(121),
-    [aux_sym_document_token1] = ACTIONS(121),
-    [anon_sym_PIPE] = ACTIONS(123),
-    [sym_text] = ACTIONS(123),
-    [aux_sym_number_token1] = ACTIONS(123),
-    [aux_sym_number_token2] = ACTIONS(123),
-    [aux_sym_float_token1] = ACTIONS(123),
-    [aux_sym_float_token2] = ACTIONS(123),
-    [anon_sym_true] = ACTIONS(123),
-    [anon_sym_false] = ACTIONS(123),
-  },
-  [28] = {
-    [ts_builtin_sym_end] = ACTIONS(23),
-    [aux_sym_document_token1] = ACTIONS(23),
-    [anon_sym_PIPE] = ACTIONS(125),
-    [sym_text] = ACTIONS(125),
-    [aux_sym_number_token1] = ACTIONS(125),
-    [aux_sym_number_token2] = ACTIONS(125),
-    [aux_sym_float_token1] = ACTIONS(125),
-    [aux_sym_float_token2] = ACTIONS(125),
-    [anon_sym_true] = ACTIONS(125),
-    [anon_sym_false] = ACTIONS(125),
-  },
-  [29] = {
-    [ts_builtin_sym_end] = ACTIONS(127),
-    [aux_sym_document_token1] = ACTIONS(127),
-    [anon_sym_PIPE] = ACTIONS(129),
-    [sym_text] = ACTIONS(129),
-    [aux_sym_number_token1] = ACTIONS(129),
-    [aux_sym_number_token2] = ACTIONS(129),
-    [aux_sym_float_token1] = ACTIONS(129),
-    [aux_sym_float_token2] = ACTIONS(129),
-    [anon_sym_true] = ACTIONS(129),
-    [anon_sym_false] = ACTIONS(129),
-  },
-  [30] = {
-    [ts_builtin_sym_end] = ACTIONS(131),
-    [aux_sym_document_token1] = ACTIONS(131),
-    [anon_sym_PIPE] = ACTIONS(133),
-    [sym_text] = ACTIONS(133),
-    [aux_sym_number_token1] = ACTIONS(133),
-    [aux_sym_number_token2] = ACTIONS(133),
-    [aux_sym_float_token1] = ACTIONS(133),
-    [aux_sym_float_token2] = ACTIONS(133),
-    [anon_sym_true] = ACTIONS(133),
-    [anon_sym_false] = ACTIONS(133),
+    [sym_field] = STATE(23),
+    [sym_number] = STATE(21),
+    [sym_float] = STATE(21),
+    [sym_boolean] = STATE(21),
+    [aux_sym_number_token1] = ACTIONS(29),
+    [aux_sym_number_token2] = ACTIONS(29),
+    [aux_sym_float_token1] = ACTIONS(31),
+    [aux_sym_float_token2] = ACTIONS(31),
+    [anon_sym_true] = ACTIONS(33),
+    [anon_sym_false] = ACTIONS(33),
+    [sym_text] = ACTIONS(35),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
   [0] = 2,
-    ACTIONS(117), 1,
-      aux_sym_document_token1,
-    ACTIONS(119), 8,
-      anon_sym_PIPE,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [14] = 2,
-    ACTIONS(121), 1,
-      aux_sym_document_token1,
-    ACTIONS(123), 8,
-      anon_sym_PIPE,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [28] = 2,
-    ACTIONS(127), 1,
-      aux_sym_document_token1,
-    ACTIONS(129), 8,
-      anon_sym_PIPE,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [42] = 2,
-    ACTIONS(44), 3,
+    ACTIONS(15), 1,
       ts_builtin_sym_end,
-      anon_sym_PIPE,
-      aux_sym_number_token2,
-    ACTIONS(135), 6,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [56] = 2,
-    ACTIONS(131), 1,
-      aux_sym_document_token1,
-    ACTIONS(133), 8,
-      anon_sym_PIPE,
-      sym_text,
+    ACTIONS(37), 7,
       aux_sym_number_token1,
       aux_sym_number_token2,
       aux_sym_float_token1,
       aux_sym_float_token2,
       anon_sym_true,
       anon_sym_false,
-  [70] = 2,
-    ACTIONS(23), 1,
-      aux_sym_document_token1,
-    ACTIONS(125), 8,
-      anon_sym_PIPE,
       sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [84] = 4,
-    ACTIONS(107), 1,
-      aux_sym_number_token2,
-    ACTIONS(137), 1,
+  [13] = 3,
+    ACTIONS(41), 1,
       anon_sym_PIPE,
-    STATE(37), 1,
+    STATE(8), 1,
       aux_sym_row_repeat1,
-    ACTIONS(112), 6,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [102] = 2,
-    ACTIONS(17), 1,
+    ACTIONS(39), 2,
       ts_builtin_sym_end,
-    ACTIONS(140), 1,
       aux_sym_document_token1,
-  [109] = 2,
-    ACTIONS(140), 1,
-      aux_sym_document_token1,
-    ACTIONS(142), 1,
+  [24] = 3,
+    ACTIONS(41), 1,
+      anon_sym_PIPE,
+    STATE(9), 1,
+      aux_sym_row_repeat1,
+    ACTIONS(43), 2,
       ts_builtin_sym_end,
-  [116] = 1,
-    ACTIONS(140), 1,
       aux_sym_document_token1,
-  [120] = 1,
-    ACTIONS(144), 1,
+  [35] = 3,
+    ACTIONS(47), 1,
+      anon_sym_PIPE,
+    STATE(9), 1,
+      aux_sym_row_repeat1,
+    ACTIONS(45), 2,
+      ts_builtin_sym_end,
+      aux_sym_document_token1,
+  [46] = 3,
+    ACTIONS(39), 1,
+      aux_sym_document_token1,
+    ACTIONS(50), 1,
+      anon_sym_PIPE,
+    STATE(16), 1,
+      aux_sym_row_repeat1,
+  [56] = 2,
+    ACTIONS(54), 1,
+      anon_sym_PIPE,
+    ACTIONS(52), 2,
+      ts_builtin_sym_end,
+      aux_sym_document_token1,
+  [64] = 2,
+    ACTIONS(58), 1,
+      anon_sym_PIPE,
+    ACTIONS(56), 2,
+      ts_builtin_sym_end,
+      aux_sym_document_token1,
+  [72] = 2,
+    ACTIONS(62), 1,
+      anon_sym_PIPE,
+    ACTIONS(60), 2,
+      ts_builtin_sym_end,
+      aux_sym_document_token1,
+  [80] = 2,
+    ACTIONS(66), 1,
+      anon_sym_PIPE,
+    ACTIONS(64), 2,
+      ts_builtin_sym_end,
+      aux_sym_document_token1,
+  [88] = 3,
+    ACTIONS(45), 1,
+      aux_sym_document_token1,
+    ACTIONS(68), 1,
+      anon_sym_PIPE,
+    STATE(15), 1,
+      aux_sym_row_repeat1,
+  [98] = 3,
+    ACTIONS(43), 1,
+      aux_sym_document_token1,
+    ACTIONS(50), 1,
+      anon_sym_PIPE,
+    STATE(15), 1,
+      aux_sym_row_repeat1,
+  [108] = 2,
+    ACTIONS(71), 1,
+      anon_sym_PIPE,
+    ACTIONS(45), 2,
+      ts_builtin_sym_end,
+      aux_sym_document_token1,
+  [116] = 2,
+    ACTIONS(52), 1,
+      aux_sym_document_token1,
+    ACTIONS(54), 1,
+      anon_sym_PIPE,
+  [123] = 2,
+    ACTIONS(56), 1,
+      aux_sym_document_token1,
+    ACTIONS(58), 1,
+      anon_sym_PIPE,
+  [130] = 2,
+    ACTIONS(60), 1,
+      aux_sym_document_token1,
+    ACTIONS(62), 1,
+      anon_sym_PIPE,
+  [137] = 2,
+    ACTIONS(64), 1,
+      aux_sym_document_token1,
+    ACTIONS(66), 1,
+      anon_sym_PIPE,
+  [144] = 2,
+    ACTIONS(73), 1,
+      ts_builtin_sym_end,
+    ACTIONS(75), 1,
+      aux_sym_document_token1,
+  [151] = 2,
+    ACTIONS(45), 1,
+      aux_sym_document_token1,
+    ACTIONS(71), 1,
+      anon_sym_PIPE,
+  [158] = 2,
+    ACTIONS(13), 1,
+      ts_builtin_sym_end,
+    ACTIONS(75), 1,
+      aux_sym_document_token1,
+  [165] = 1,
+    ACTIONS(75), 1,
+      aux_sym_document_token1,
+  [169] = 1,
+    ACTIONS(77), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(31)] = 0,
-  [SMALL_STATE(32)] = 14,
-  [SMALL_STATE(33)] = 28,
-  [SMALL_STATE(34)] = 42,
-  [SMALL_STATE(35)] = 56,
-  [SMALL_STATE(36)] = 70,
-  [SMALL_STATE(37)] = 84,
-  [SMALL_STATE(38)] = 102,
-  [SMALL_STATE(39)] = 109,
-  [SMALL_STATE(40)] = 116,
-  [SMALL_STATE(41)] = 120,
+  [SMALL_STATE(6)] = 0,
+  [SMALL_STATE(7)] = 13,
+  [SMALL_STATE(8)] = 24,
+  [SMALL_STATE(9)] = 35,
+  [SMALL_STATE(10)] = 46,
+  [SMALL_STATE(11)] = 56,
+  [SMALL_STATE(12)] = 64,
+  [SMALL_STATE(13)] = 72,
+  [SMALL_STATE(14)] = 80,
+  [SMALL_STATE(15)] = 88,
+  [SMALL_STATE(16)] = 98,
+  [SMALL_STATE(17)] = 108,
+  [SMALL_STATE(18)] = 116,
+  [SMALL_STATE(19)] = 123,
+  [SMALL_STATE(20)] = 130,
+  [SMALL_STATE(21)] = 137,
+  [SMALL_STATE(22)] = 144,
+  [SMALL_STATE(23)] = 151,
+  [SMALL_STATE(24)] = 158,
+  [SMALL_STATE(25)] = 165,
+  [SMALL_STATE(26)] = 169,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
-  [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 3, 0, 0),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [23] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0),
-  [25] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(23),
-  [28] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(30),
-  [31] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(26),
-  [34] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(27),
-  [37] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(29),
-  [40] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 2, 0, 0),
-  [42] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
-  [44] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
-  [49] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(35),
-  [52] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(31),
-  [55] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(31),
-  [58] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(32),
-  [61] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(33),
-  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 1, 0, 0),
-  [66] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
-  [68] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
-  [70] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
-  [72] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
-  [74] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
-  [76] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [78] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [80] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [82] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(22),
-  [85] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(35),
-  [88] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(31),
-  [91] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(32),
-  [94] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(33),
-  [97] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
-  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 4, 0, 0),
-  [101] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0),
-  [109] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0), SHIFT_REPEAT(24),
-  [112] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0),
-  [114] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0), SHIFT_REPEAT(25),
-  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_number, 1, 0, 0),
-  [119] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_number, 1, 0, 0),
-  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1, 0, 0),
-  [123] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1, 0, 0),
-  [125] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0),
-  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean, 1, 0, 0),
-  [129] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_boolean, 1, 0, 0),
-  [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_field, 1, 0, 0),
-  [133] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_field, 1, 0, 0),
-  [135] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [137] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0), SHIFT_REPEAT(37),
-  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 0),
-  [144] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
+  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1),
+  [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
+  [17] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(18),
+  [20] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(19),
+  [23] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(20),
+  [26] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(21),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
+  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
+  [37] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2),
+  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 1),
+  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
+  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 2),
+  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_row_repeat1, 2),
+  [47] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2), SHIFT_REPEAT(4),
+  [50] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
+  [52] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_number, 1),
+  [54] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_number, 1),
+  [56] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1),
+  [58] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1),
+  [60] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean, 1),
+  [62] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_boolean, 1),
+  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_field, 1),
+  [66] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_field, 1),
+  [68] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2), SHIFT_REPEAT(5),
+  [71] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2),
+  [73] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2),
+  [75] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [77] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
 };
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-#ifdef TREE_SITTER_HIDE_SYMBOLS
-#define TS_PUBLIC
-#elif defined(_WIN32)
-#define TS_PUBLIC __declspec(dllexport)
-#else
-#define TS_PUBLIC __attribute__((visibility("default")))
+#ifdef _WIN32
+#define extern __declspec(dllexport)
 #endif
 
-TS_PUBLIC const TSLanguage *tree_sitter_psv(void) {
+extern const TSLanguage *tree_sitter_psv(void) {
   static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,

--- a/psv/src/tree_sitter/parser.h
+++ b/psv/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -86,11 +87,6 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
-typedef struct {
-  int32_t start;
-  int32_t end;
-} TSCharacterRange;
-
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -130,38 +126,13 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
-  uint32_t index = 0;
-  uint32_t size = len - index;
-  while (size > 1) {
-    uint32_t half_size = size / 2;
-    uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
-    if (lookahead >= range->start && lookahead <= range->end) {
-      return true;
-    } else if (lookahead > range->end) {
-      index = mid_index;
-    }
-    size -= half_size;
-  }
-  TSCharacterRange *range = &ranges[index];
-  return (lookahead >= range->start && lookahead <= range->end);
-}
-
 /*
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -175,17 +146,6 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {                          \
     state = state_value;     \
     goto next_state;         \
-  }
-
-#define ADVANCE_MAP(...)                                              \
-  {                                                                   \
-    static const uint16_t map[] = { __VA_ARGS__ };                    \
-    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
-      if (map[i] == lookahead) {                                      \
-        state = map[i + 1];                                           \
-        goto next_state;                                              \
-      }                                                               \
-    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -206,7 +166,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -216,7 +176,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -224,7 +184,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}
@@ -237,15 +197,14 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }                                 \
   }}
 
-#define REDUCE(symbol_name, children, precedence, prod_id) \
-  {{                                                       \
-    .reduce = {                                            \
-      .type = TSParseActionTypeReduce,                     \
-      .symbol = symbol_name,                               \
-      .child_count = children,                             \
-      .dynamic_precedence = precedence,                    \
-      .production_id = prod_id                             \
-    },                                                     \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
   }}
 
 #define RECOVER()                    \

--- a/tsv/src/grammar.json
+++ b/tsv/src/grammar.json
@@ -35,55 +35,26 @@
       ]
     },
     "row": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "STRING",
-                "value": "\t"
-              }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "field"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "STRING",
-                      "value": "\t"
-                    }
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "field"
-                  }
-                ]
-              }
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "STRING",
-                "value": "\t"
-              }
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "field"
         },
         {
-          "type": "REPEAT1",
+          "type": "REPEAT",
           "content": {
-            "type": "STRING",
-            "value": "\t"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\t"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "field"
+              }
+            ]
           }
         }
       ]
@@ -108,47 +79,6 @@
           "name": "boolean"
         }
       ]
-    },
-    "text": {
-      "type": "TOKEN",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "PATTERN",
-            "value": "[^\t\\d\\s\"][^\t \\n\\r\"]+"
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "\""
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "[^\"]"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "\"\""
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "STRING",
-                "value": "\""
-              }
-            ]
-          }
-        ]
-      }
     },
     "number": {
       "type": "CHOICE",
@@ -188,6 +118,47 @@
           "value": "false"
         }
       ]
+    },
+    "text": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "PATTERN",
+            "value": "[^\t\\r\\n]*"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\""
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "PATTERN",
+                      "value": "[^\"]"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "\"\""
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "STRING",
+                "value": "\""
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   "extras": [
@@ -202,3 +173,4 @@
   "inline": [],
   "supertypes": []
 }
+

--- a/tsv/src/node-types.json
+++ b/tsv/src/node-types.json
@@ -62,7 +62,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "field",

--- a/tsv/src/parser.c
+++ b/tsv/src/parser.c
@@ -1,30 +1,31 @@
-#include "tree_sitter/parser.h"
+#include <tree_sitter/parser.h>
 
 #if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 42
-#define LARGE_STATE_COUNT 31
-#define SYMBOL_COUNT 19
+#define STATE_COUNT 27
+#define LARGE_STATE_COUNT 6
+#define SYMBOL_COUNT 18
 #define ALIAS_COUNT 0
 #define TOKEN_COUNT 10
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 0
-#define MAX_ALIAS_SEQUENCE_LENGTH 4
+#define MAX_ALIAS_SEQUENCE_LENGTH 2
 #define PRODUCTION_ID_COUNT 1
 
-enum ts_symbol_identifiers {
+enum {
   aux_sym_document_token1 = 1,
   anon_sym_TAB = 2,
-  sym_text = 3,
-  aux_sym_number_token1 = 4,
-  aux_sym_number_token2 = 5,
-  aux_sym_float_token1 = 6,
-  aux_sym_float_token2 = 7,
-  anon_sym_true = 8,
-  anon_sym_false = 9,
+  aux_sym_number_token1 = 3,
+  aux_sym_number_token2 = 4,
+  aux_sym_float_token1 = 5,
+  aux_sym_float_token2 = 6,
+  anon_sym_true = 7,
+  anon_sym_false = 8,
+  sym_text = 9,
   sym_document = 10,
   sym_row = 11,
   sym_field = 12,
@@ -33,20 +34,19 @@ enum ts_symbol_identifiers {
   sym_boolean = 15,
   aux_sym_document_repeat1 = 16,
   aux_sym_row_repeat1 = 17,
-  aux_sym_row_repeat2 = 18,
 };
 
 static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
   [aux_sym_document_token1] = "document_token1",
   [anon_sym_TAB] = "\t",
-  [sym_text] = "text",
   [aux_sym_number_token1] = "number_token1",
   [aux_sym_number_token2] = "number_token2",
   [aux_sym_float_token1] = "float_token1",
   [aux_sym_float_token2] = "float_token2",
   [anon_sym_true] = "true",
   [anon_sym_false] = "false",
+  [sym_text] = "text",
   [sym_document] = "document",
   [sym_row] = "row",
   [sym_field] = "field",
@@ -55,20 +55,19 @@ static const char * const ts_symbol_names[] = {
   [sym_boolean] = "boolean",
   [aux_sym_document_repeat1] = "document_repeat1",
   [aux_sym_row_repeat1] = "row_repeat1",
-  [aux_sym_row_repeat2] = "row_repeat2",
 };
 
 static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
   [aux_sym_document_token1] = aux_sym_document_token1,
   [anon_sym_TAB] = anon_sym_TAB,
-  [sym_text] = sym_text,
   [aux_sym_number_token1] = aux_sym_number_token1,
   [aux_sym_number_token2] = aux_sym_number_token2,
   [aux_sym_float_token1] = aux_sym_float_token1,
   [aux_sym_float_token2] = aux_sym_float_token2,
   [anon_sym_true] = anon_sym_true,
   [anon_sym_false] = anon_sym_false,
+  [sym_text] = sym_text,
   [sym_document] = sym_document,
   [sym_row] = sym_row,
   [sym_field] = sym_field,
@@ -77,7 +76,6 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_boolean] = sym_boolean,
   [aux_sym_document_repeat1] = aux_sym_document_repeat1,
   [aux_sym_row_repeat1] = aux_sym_row_repeat1,
-  [aux_sym_row_repeat2] = aux_sym_row_repeat2,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -92,10 +90,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [anon_sym_TAB] = {
     .visible = true,
     .named = false,
-  },
-  [sym_text] = {
-    .visible = true,
-    .named = true,
   },
   [aux_sym_number_token1] = {
     .visible = false,
@@ -120,6 +114,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [anon_sym_false] = {
     .visible = true,
     .named = false,
+  },
+  [sym_text] = {
+    .visible = true,
+    .named = true,
   },
   [sym_document] = {
     .visible = true,
@@ -153,10 +151,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_row_repeat2] = {
-    .visible = false,
-    .named = false,
-  },
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
@@ -173,43 +167,28 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [2] = 2,
   [3] = 3,
   [4] = 4,
-  [5] = 5,
+  [5] = 4,
   [6] = 6,
   [7] = 7,
   [8] = 8,
   [9] = 9,
-  [10] = 8,
+  [10] = 7,
   [11] = 11,
-  [12] = 3,
-  [13] = 4,
-  [14] = 5,
-  [15] = 15,
-  [16] = 7,
+  [12] = 12,
+  [13] = 13,
+  [14] = 14,
+  [15] = 9,
+  [16] = 8,
   [17] = 17,
-  [18] = 17,
-  [19] = 15,
-  [20] = 11,
-  [21] = 9,
+  [18] = 11,
+  [19] = 12,
+  [20] = 13,
+  [21] = 14,
   [22] = 22,
-  [23] = 22,
+  [23] = 17,
   [24] = 24,
-  [25] = 24,
+  [25] = 25,
   [26] = 26,
-  [27] = 27,
-  [28] = 28,
-  [29] = 29,
-  [30] = 30,
-  [31] = 26,
-  [32] = 27,
-  [33] = 29,
-  [34] = 34,
-  [35] = 30,
-  [36] = 28,
-  [37] = 24,
-  [38] = 38,
-  [39] = 39,
-  [40] = 40,
-  [41] = 41,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -217,227 +196,232 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(9);
-      ADVANCE_MAP(
-        '\t', 12,
-        '\n', 10,
-        '\r', 10,
-        '"', 1,
-        '.', 4,
-        '0', 22,
-        'f', 2,
-        't', 3,
-      );
-      if (lookahead == 0x0b ||
-          lookahead == '\f' ||
-          lookahead == ' ') SKIP(0);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(23);
-      if (lookahead != 0) ADVANCE(6);
+      ACCEPT_TOKEN(sym_text);
+      if (eof) ADVANCE(4);
+      if (lookahead == ' ') ADVANCE(15);
+      if (lookahead == '"') ADVANCE(17);
+      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == '0') ADVANCE(8);
+      if (lookahead == 'f') ADVANCE(19);
+      if (lookahead == 't') ADVANCE(23);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(9);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(14);
+      if (lookahead == '"') ADVANCE(18);
       if (lookahead != 0) ADVANCE(1);
       END_STATE();
     case 2:
-      if (lookahead == 'a') ADVANCE(17);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
+      if (eof) ADVANCE(4);
+      if (lookahead == '\t') ADVANCE(7);
+      if (lookahead == '\n') ADVANCE(5);
+      if (lookahead == '\r') ADVANCE(5);
+      if (lookahead == ' ') SKIP(2)
       END_STATE();
     case 3:
-      if (lookahead == 'r') ADVANCE(19);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
+      if (eof) ADVANCE(4);
+      if (lookahead == '\n') ADVANCE(6);
+      if (lookahead == '\r') ADVANCE(6);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(3)
       END_STATE();
     case 4:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(20);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
-      END_STATE();
-    case 5:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(24);
-      END_STATE();
-    case 6:
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
-      END_STATE();
-    case 7:
-      if (eof) ADVANCE(9);
-      if (lookahead == '\t') ADVANCE(13);
-      if (lookahead == '"') ADVANCE(1);
-      if (lookahead == '.') ADVANCE(4);
-      if (lookahead == '0') ADVANCE(22);
-      if (lookahead == 'f') ADVANCE(2);
-      if (lookahead == 't') ADVANCE(3);
-      if (('\n' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(7);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(23);
-      if (lookahead != 0) ADVANCE(6);
-      END_STATE();
-    case 8:
-      if (eof) ADVANCE(9);
-      if (lookahead == '\n') ADVANCE(11);
-      if (lookahead == '\r') ADVANCE(11);
-      if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') SKIP(8);
-      END_STATE();
-    case 9:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 10:
+    case 5:
       ACCEPT_TOKEN(aux_sym_document_token1);
-      if (lookahead == '\t') ADVANCE(12);
-      if (lookahead == '\n') ADVANCE(10);
-      if (lookahead == '\r') ADVANCE(10);
+      if (lookahead == '\t') ADVANCE(7);
+      if (lookahead == '\n') ADVANCE(5);
+      if (lookahead == '\r') ADVANCE(5);
       END_STATE();
-    case 11:
+    case 6:
       ACCEPT_TOKEN(aux_sym_document_token1);
-      if (lookahead == '\n') ADVANCE(11);
-      if (lookahead == '\r') ADVANCE(11);
+      if (lookahead == '\n') ADVANCE(6);
+      if (lookahead == '\r') ADVANCE(6);
       END_STATE();
-    case 12:
+    case 7:
       ACCEPT_TOKEN(anon_sym_TAB);
-      if (lookahead == '\t') ADVANCE(12);
-      if (lookahead == '\n') ADVANCE(10);
-      if (lookahead == '\r') ADVANCE(10);
+      if (lookahead == '\t') ADVANCE(7);
+      if (lookahead == '\n') ADVANCE(5);
+      if (lookahead == '\r') ADVANCE(5);
       END_STATE();
-    case 13:
-      ACCEPT_TOKEN(anon_sym_TAB);
-      if (lookahead == '\t') ADVANCE(13);
-      END_STATE();
-    case 14:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == '"') ADVANCE(1);
-      END_STATE();
-    case 15:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e') ADVANCE(27);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
-      END_STATE();
-    case 16:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e') ADVANCE(28);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
-      END_STATE();
-    case 17:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l') ADVANCE(18);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
-      END_STATE();
-    case 18:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 's') ADVANCE(16);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
-      END_STATE();
-    case 19:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'u') ADVANCE(15);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
-      END_STATE();
-    case 20:
-      ACCEPT_TOKEN(sym_text);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(20);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
-      END_STATE();
-    case 21:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
-      END_STATE();
-    case 22:
+    case 8:
       ACCEPT_TOKEN(aux_sym_number_token1);
-      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == '.') ADVANCE(12);
       if (lookahead == 'X' ||
-          lookahead == 'x') ADVANCE(5);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(23);
+          lookahead == 'x') ADVANCE(27);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(9);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
       END_STATE();
-    case 23:
+    case 9:
       ACCEPT_TOKEN(aux_sym_number_token1);
-      if (lookahead == '.') ADVANCE(26);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(23);
+      if (lookahead == '.') ADVANCE(12);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(9);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
       END_STATE();
-    case 24:
+    case 10:
       ACCEPT_TOKEN(aux_sym_number_token2);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(24);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(10);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
       END_STATE();
-    case 25:
+    case 11:
       ACCEPT_TOKEN(aux_sym_float_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(25);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(11);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
       END_STATE();
-    case 26:
+    case 12:
       ACCEPT_TOKEN(aux_sym_float_token2);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(25);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(11);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
       END_STATE();
-    case 27:
+    case 13:
       ACCEPT_TOKEN(anon_sym_true);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
+          lookahead != '\r') ADVANCE(28);
       END_STATE();
-    case 28:
+    case 14:
       ACCEPT_TOKEN(anon_sym_false);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != '"') ADVANCE(21);
+          lookahead != '\r') ADVANCE(28);
+      END_STATE();
+    case 15:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == ' ') ADVANCE(15);
+      if (lookahead == '"') ADVANCE(17);
+      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == '0') ADVANCE(8);
+      if (lookahead == 'f') ADVANCE(19);
+      if (lookahead == 't') ADVANCE(23);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(9);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
+      END_STATE();
+    case 16:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '"') ADVANCE(17);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
+      END_STATE();
+    case 17:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '"') ADVANCE(16);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r') ADVANCE(1);
+      if (lookahead != 0) ADVANCE(17);
+      END_STATE();
+    case 18:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == '"') ADVANCE(1);
+      END_STATE();
+    case 19:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'a') ADVANCE(22);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
+      END_STATE();
+    case 20:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'e') ADVANCE(13);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
+      END_STATE();
+    case 21:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'e') ADVANCE(14);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
+      END_STATE();
+    case 22:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'l') ADVANCE(24);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
+      END_STATE();
+    case 23:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'r') ADVANCE(25);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
+      END_STATE();
+    case 24:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 's') ADVANCE(21);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
+      END_STATE();
+    case 25:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'u') ADVANCE(20);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
+      END_STATE();
+    case 26:
+      ACCEPT_TOKEN(sym_text);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(11);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
+      END_STATE();
+    case 27:
+      ACCEPT_TOKEN(sym_text);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(10);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
+      END_STATE();
+    case 28:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(28);
       END_STATE();
     default:
       return false;
@@ -446,734 +430,324 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 7},
-  [2] = {.lex_state = 7},
+  [1] = {.lex_state = 0},
+  [2] = {.lex_state = 0},
   [3] = {.lex_state = 0},
   [4] = {.lex_state = 0},
   [5] = {.lex_state = 0},
-  [6] = {.lex_state = 7},
-  [7] = {.lex_state = 0},
-  [8] = {.lex_state = 0},
-  [9] = {.lex_state = 0},
-  [10] = {.lex_state = 0},
-  [11] = {.lex_state = 0},
-  [12] = {.lex_state = 0},
-  [13] = {.lex_state = 0},
-  [14] = {.lex_state = 0},
-  [15] = {.lex_state = 0},
-  [16] = {.lex_state = 0},
-  [17] = {.lex_state = 0},
-  [18] = {.lex_state = 0},
-  [19] = {.lex_state = 0},
-  [20] = {.lex_state = 0},
-  [21] = {.lex_state = 0},
-  [22] = {.lex_state = 7},
-  [23] = {.lex_state = 7},
-  [24] = {.lex_state = 0},
-  [25] = {.lex_state = 0},
+  [6] = {.lex_state = 0},
+  [7] = {.lex_state = 2},
+  [8] = {.lex_state = 2},
+  [9] = {.lex_state = 2},
+  [10] = {.lex_state = 2},
+  [11] = {.lex_state = 2},
+  [12] = {.lex_state = 2},
+  [13] = {.lex_state = 2},
+  [14] = {.lex_state = 2},
+  [15] = {.lex_state = 2},
+  [16] = {.lex_state = 2},
+  [17] = {.lex_state = 2},
+  [18] = {.lex_state = 2},
+  [19] = {.lex_state = 2},
+  [20] = {.lex_state = 2},
+  [21] = {.lex_state = 2},
+  [22] = {.lex_state = 3},
+  [23] = {.lex_state = 2},
+  [24] = {.lex_state = 3},
+  [25] = {.lex_state = 3},
   [26] = {.lex_state = 0},
-  [27] = {.lex_state = 0},
-  [28] = {.lex_state = 0},
-  [29] = {.lex_state = 0},
-  [30] = {.lex_state = 0},
-  [31] = {.lex_state = 0},
-  [32] = {.lex_state = 0},
-  [33] = {.lex_state = 0},
-  [34] = {.lex_state = 7},
-  [35] = {.lex_state = 0},
-  [36] = {.lex_state = 0},
-  [37] = {.lex_state = 7},
-  [38] = {.lex_state = 8},
-  [39] = {.lex_state = 8},
-  [40] = {.lex_state = 8},
-  [41] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
-    [aux_sym_document_token1] = ACTIONS(1),
-    [anon_sym_TAB] = ACTIONS(1),
-    [sym_text] = ACTIONS(1),
     [aux_sym_number_token1] = ACTIONS(1),
     [aux_sym_number_token2] = ACTIONS(1),
     [aux_sym_float_token1] = ACTIONS(1),
     [aux_sym_float_token2] = ACTIONS(1),
     [anon_sym_true] = ACTIONS(1),
     [anon_sym_false] = ACTIONS(1),
+    [sym_text] = ACTIONS(1),
   },
   [1] = {
-    [sym_document] = STATE(41),
-    [sym_row] = STATE(38),
-    [sym_field] = STATE(8),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
+    [sym_document] = STATE(26),
+    [sym_row] = STATE(24),
+    [sym_field] = STATE(7),
+    [sym_number] = STATE(14),
+    [sym_float] = STATE(14),
+    [sym_boolean] = STATE(14),
     [aux_sym_document_repeat1] = STATE(2),
-    [aux_sym_row_repeat1] = STATE(9),
     [ts_builtin_sym_end] = ACTIONS(3),
-    [anon_sym_TAB] = ACTIONS(5),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(11),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [anon_sym_true] = ACTIONS(13),
-    [anon_sym_false] = ACTIONS(13),
+    [aux_sym_number_token1] = ACTIONS(5),
+    [aux_sym_number_token2] = ACTIONS(5),
+    [aux_sym_float_token1] = ACTIONS(7),
+    [aux_sym_float_token2] = ACTIONS(7),
+    [anon_sym_true] = ACTIONS(9),
+    [anon_sym_false] = ACTIONS(9),
+    [sym_text] = ACTIONS(11),
   },
   [2] = {
-    [sym_row] = STATE(39),
-    [sym_field] = STATE(8),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_document_repeat1] = STATE(6),
-    [aux_sym_row_repeat1] = STATE(9),
-    [ts_builtin_sym_end] = ACTIONS(15),
-    [anon_sym_TAB] = ACTIONS(5),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(11),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [anon_sym_true] = ACTIONS(13),
-    [anon_sym_false] = ACTIONS(13),
+    [sym_row] = STATE(22),
+    [sym_field] = STATE(7),
+    [sym_number] = STATE(14),
+    [sym_float] = STATE(14),
+    [sym_boolean] = STATE(14),
+    [aux_sym_document_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(13),
+    [aux_sym_number_token1] = ACTIONS(5),
+    [aux_sym_number_token2] = ACTIONS(5),
+    [aux_sym_float_token1] = ACTIONS(7),
+    [aux_sym_float_token2] = ACTIONS(7),
+    [anon_sym_true] = ACTIONS(9),
+    [anon_sym_false] = ACTIONS(9),
+    [sym_text] = ACTIONS(11),
   },
   [3] = {
-    [sym_field] = STATE(4),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(17),
-    [aux_sym_row_repeat2] = STATE(4),
-    [ts_builtin_sym_end] = ACTIONS(17),
-    [aux_sym_document_token1] = ACTIONS(19),
-    [anon_sym_TAB] = ACTIONS(21),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(11),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [anon_sym_true] = ACTIONS(13),
-    [anon_sym_false] = ACTIONS(13),
+    [sym_row] = STATE(25),
+    [sym_field] = STATE(10),
+    [sym_number] = STATE(21),
+    [sym_float] = STATE(21),
+    [sym_boolean] = STATE(21),
+    [aux_sym_document_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(15),
+    [aux_sym_number_token1] = ACTIONS(17),
+    [aux_sym_number_token2] = ACTIONS(17),
+    [aux_sym_float_token1] = ACTIONS(20),
+    [aux_sym_float_token2] = ACTIONS(20),
+    [anon_sym_true] = ACTIONS(23),
+    [anon_sym_false] = ACTIONS(23),
+    [sym_text] = ACTIONS(26),
   },
   [4] = {
-    [sym_field] = STATE(4),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(23),
-    [aux_sym_row_repeat2] = STATE(4),
-    [ts_builtin_sym_end] = ACTIONS(23),
-    [aux_sym_document_token1] = ACTIONS(25),
-    [anon_sym_TAB] = ACTIONS(27),
-    [sym_text] = ACTIONS(30),
-    [aux_sym_number_token1] = ACTIONS(33),
-    [aux_sym_number_token2] = ACTIONS(33),
-    [aux_sym_float_token1] = ACTIONS(36),
-    [aux_sym_float_token2] = ACTIONS(36),
-    [anon_sym_true] = ACTIONS(39),
-    [anon_sym_false] = ACTIONS(39),
+    [sym_field] = STATE(17),
+    [sym_number] = STATE(14),
+    [sym_float] = STATE(14),
+    [sym_boolean] = STATE(14),
+    [aux_sym_number_token1] = ACTIONS(5),
+    [aux_sym_number_token2] = ACTIONS(5),
+    [aux_sym_float_token1] = ACTIONS(7),
+    [aux_sym_float_token2] = ACTIONS(7),
+    [anon_sym_true] = ACTIONS(9),
+    [anon_sym_false] = ACTIONS(9),
+    [sym_text] = ACTIONS(11),
   },
   [5] = {
-    [sym_field] = STATE(3),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(15),
-    [aux_sym_row_repeat2] = STATE(3),
-    [ts_builtin_sym_end] = ACTIONS(42),
-    [aux_sym_document_token1] = ACTIONS(44),
-    [anon_sym_TAB] = ACTIONS(46),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(11),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [anon_sym_true] = ACTIONS(13),
-    [anon_sym_false] = ACTIONS(13),
-  },
-  [6] = {
-    [sym_row] = STATE(40),
-    [sym_field] = STATE(10),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_document_repeat1] = STATE(6),
-    [aux_sym_row_repeat1] = STATE(21),
-    [ts_builtin_sym_end] = ACTIONS(48),
-    [anon_sym_TAB] = ACTIONS(50),
-    [sym_text] = ACTIONS(53),
-    [aux_sym_number_token1] = ACTIONS(56),
-    [aux_sym_number_token2] = ACTIONS(56),
-    [aux_sym_float_token1] = ACTIONS(59),
-    [aux_sym_float_token2] = ACTIONS(59),
-    [anon_sym_true] = ACTIONS(62),
-    [anon_sym_false] = ACTIONS(62),
-  },
-  [7] = {
-    [sym_field] = STATE(4),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(15),
-    [aux_sym_row_repeat2] = STATE(4),
-    [ts_builtin_sym_end] = ACTIONS(42),
-    [aux_sym_document_token1] = ACTIONS(44),
-    [anon_sym_TAB] = ACTIONS(46),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(11),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [anon_sym_true] = ACTIONS(13),
-    [anon_sym_false] = ACTIONS(13),
-  },
-  [8] = {
-    [sym_field] = STATE(7),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(11),
-    [aux_sym_row_repeat2] = STATE(7),
-    [ts_builtin_sym_end] = ACTIONS(65),
-    [aux_sym_document_token1] = ACTIONS(67),
-    [anon_sym_TAB] = ACTIONS(69),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(11),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [anon_sym_true] = ACTIONS(13),
-    [anon_sym_false] = ACTIONS(13),
-  },
-  [9] = {
-    [sym_field] = STATE(5),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(65),
-    [aux_sym_document_token1] = ACTIONS(67),
-    [anon_sym_TAB] = ACTIONS(71),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(11),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [anon_sym_true] = ACTIONS(13),
-    [anon_sym_false] = ACTIONS(13),
-  },
-  [10] = {
-    [sym_field] = STATE(16),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(20),
-    [aux_sym_row_repeat2] = STATE(16),
-    [aux_sym_document_token1] = ACTIONS(67),
-    [anon_sym_TAB] = ACTIONS(73),
-    [sym_text] = ACTIONS(75),
-    [aux_sym_number_token1] = ACTIONS(77),
-    [aux_sym_number_token2] = ACTIONS(77),
-    [aux_sym_float_token1] = ACTIONS(79),
-    [aux_sym_float_token2] = ACTIONS(79),
-    [anon_sym_true] = ACTIONS(81),
-    [anon_sym_false] = ACTIONS(81),
-  },
-  [11] = {
-    [sym_field] = STATE(28),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(42),
-    [aux_sym_document_token1] = ACTIONS(44),
-    [anon_sym_TAB] = ACTIONS(71),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(11),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [anon_sym_true] = ACTIONS(13),
-    [anon_sym_false] = ACTIONS(13),
-  },
-  [12] = {
-    [sym_field] = STATE(13),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(18),
-    [aux_sym_row_repeat2] = STATE(13),
-    [aux_sym_document_token1] = ACTIONS(19),
-    [anon_sym_TAB] = ACTIONS(83),
-    [sym_text] = ACTIONS(75),
-    [aux_sym_number_token1] = ACTIONS(77),
-    [aux_sym_number_token2] = ACTIONS(77),
-    [aux_sym_float_token1] = ACTIONS(79),
-    [aux_sym_float_token2] = ACTIONS(79),
-    [anon_sym_true] = ACTIONS(81),
-    [anon_sym_false] = ACTIONS(81),
-  },
-  [13] = {
-    [sym_field] = STATE(13),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(22),
-    [aux_sym_row_repeat2] = STATE(13),
-    [aux_sym_document_token1] = ACTIONS(25),
-    [anon_sym_TAB] = ACTIONS(85),
-    [sym_text] = ACTIONS(88),
-    [aux_sym_number_token1] = ACTIONS(91),
-    [aux_sym_number_token2] = ACTIONS(91),
-    [aux_sym_float_token1] = ACTIONS(94),
-    [aux_sym_float_token2] = ACTIONS(94),
-    [anon_sym_true] = ACTIONS(97),
-    [anon_sym_false] = ACTIONS(97),
-  },
-  [14] = {
-    [sym_field] = STATE(12),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(19),
-    [aux_sym_row_repeat2] = STATE(12),
-    [aux_sym_document_token1] = ACTIONS(44),
-    [anon_sym_TAB] = ACTIONS(100),
-    [sym_text] = ACTIONS(75),
-    [aux_sym_number_token1] = ACTIONS(77),
-    [aux_sym_number_token2] = ACTIONS(77),
-    [aux_sym_float_token1] = ACTIONS(79),
-    [aux_sym_float_token2] = ACTIONS(79),
-    [anon_sym_true] = ACTIONS(81),
-    [anon_sym_false] = ACTIONS(81),
-  },
-  [15] = {
-    [sym_field] = STATE(28),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(17),
-    [aux_sym_document_token1] = ACTIONS(19),
-    [anon_sym_TAB] = ACTIONS(71),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(11),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [anon_sym_true] = ACTIONS(13),
-    [anon_sym_false] = ACTIONS(13),
-  },
-  [16] = {
-    [sym_field] = STATE(13),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(19),
-    [aux_sym_row_repeat2] = STATE(13),
-    [aux_sym_document_token1] = ACTIONS(44),
-    [anon_sym_TAB] = ACTIONS(100),
-    [sym_text] = ACTIONS(75),
-    [aux_sym_number_token1] = ACTIONS(77),
-    [aux_sym_number_token2] = ACTIONS(77),
-    [aux_sym_float_token1] = ACTIONS(79),
-    [aux_sym_float_token2] = ACTIONS(79),
-    [anon_sym_true] = ACTIONS(81),
-    [anon_sym_false] = ACTIONS(81),
-  },
-  [17] = {
-    [sym_field] = STATE(28),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(102),
-    [aux_sym_document_token1] = ACTIONS(104),
-    [anon_sym_TAB] = ACTIONS(71),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(11),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [anon_sym_true] = ACTIONS(13),
-    [anon_sym_false] = ACTIONS(13),
-  },
-  [18] = {
-    [sym_field] = STATE(36),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(104),
-    [anon_sym_TAB] = ACTIONS(106),
-    [sym_text] = ACTIONS(75),
-    [aux_sym_number_token1] = ACTIONS(77),
-    [aux_sym_number_token2] = ACTIONS(77),
-    [aux_sym_float_token1] = ACTIONS(79),
-    [aux_sym_float_token2] = ACTIONS(79),
-    [anon_sym_true] = ACTIONS(81),
-    [anon_sym_false] = ACTIONS(81),
-  },
-  [19] = {
-    [sym_field] = STATE(36),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(19),
-    [anon_sym_TAB] = ACTIONS(106),
-    [sym_text] = ACTIONS(75),
-    [aux_sym_number_token1] = ACTIONS(77),
-    [aux_sym_number_token2] = ACTIONS(77),
-    [aux_sym_float_token1] = ACTIONS(79),
-    [aux_sym_float_token2] = ACTIONS(79),
-    [anon_sym_true] = ACTIONS(81),
-    [anon_sym_false] = ACTIONS(81),
-  },
-  [20] = {
-    [sym_field] = STATE(36),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(44),
-    [anon_sym_TAB] = ACTIONS(106),
-    [sym_text] = ACTIONS(75),
-    [aux_sym_number_token1] = ACTIONS(77),
-    [aux_sym_number_token2] = ACTIONS(77),
-    [aux_sym_float_token1] = ACTIONS(79),
-    [aux_sym_float_token2] = ACTIONS(79),
-    [anon_sym_true] = ACTIONS(81),
-    [anon_sym_false] = ACTIONS(81),
-  },
-  [21] = {
-    [sym_field] = STATE(14),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(67),
-    [anon_sym_TAB] = ACTIONS(106),
-    [sym_text] = ACTIONS(75),
-    [aux_sym_number_token1] = ACTIONS(77),
-    [aux_sym_number_token2] = ACTIONS(77),
-    [aux_sym_float_token1] = ACTIONS(79),
-    [aux_sym_float_token2] = ACTIONS(79),
-    [anon_sym_true] = ACTIONS(81),
-    [anon_sym_false] = ACTIONS(81),
-  },
-  [22] = {
-    [sym_field] = STATE(36),
-    [sym_number] = STATE(35),
-    [sym_float] = STATE(35),
-    [sym_boolean] = STATE(35),
-    [aux_sym_row_repeat1] = STATE(37),
-    [anon_sym_TAB] = ACTIONS(108),
-    [sym_text] = ACTIONS(75),
-    [aux_sym_number_token1] = ACTIONS(77),
-    [aux_sym_number_token2] = ACTIONS(77),
-    [aux_sym_float_token1] = ACTIONS(79),
-    [aux_sym_float_token2] = ACTIONS(79),
-    [anon_sym_true] = ACTIONS(81),
-    [anon_sym_false] = ACTIONS(81),
-  },
-  [23] = {
-    [sym_field] = STATE(28),
-    [sym_number] = STATE(30),
-    [sym_float] = STATE(30),
-    [sym_boolean] = STATE(30),
-    [aux_sym_row_repeat1] = STATE(37),
-    [anon_sym_TAB] = ACTIONS(108),
-    [sym_text] = ACTIONS(7),
-    [aux_sym_number_token1] = ACTIONS(9),
-    [aux_sym_number_token2] = ACTIONS(9),
-    [aux_sym_float_token1] = ACTIONS(11),
-    [aux_sym_float_token2] = ACTIONS(11),
-    [anon_sym_true] = ACTIONS(13),
-    [anon_sym_false] = ACTIONS(13),
-  },
-  [24] = {
-    [aux_sym_row_repeat1] = STATE(24),
-    [ts_builtin_sym_end] = ACTIONS(110),
-    [aux_sym_document_token1] = ACTIONS(112),
-    [anon_sym_TAB] = ACTIONS(114),
-    [sym_text] = ACTIONS(112),
-    [aux_sym_number_token1] = ACTIONS(112),
-    [aux_sym_number_token2] = ACTIONS(112),
-    [aux_sym_float_token1] = ACTIONS(112),
-    [aux_sym_float_token2] = ACTIONS(112),
-    [anon_sym_true] = ACTIONS(112),
-    [anon_sym_false] = ACTIONS(112),
-  },
-  [25] = {
-    [aux_sym_row_repeat1] = STATE(25),
-    [aux_sym_document_token1] = ACTIONS(112),
-    [anon_sym_TAB] = ACTIONS(117),
-    [sym_text] = ACTIONS(112),
-    [aux_sym_number_token1] = ACTIONS(112),
-    [aux_sym_number_token2] = ACTIONS(112),
-    [aux_sym_float_token1] = ACTIONS(112),
-    [aux_sym_float_token2] = ACTIONS(112),
-    [anon_sym_true] = ACTIONS(112),
-    [anon_sym_false] = ACTIONS(112),
-  },
-  [26] = {
-    [ts_builtin_sym_end] = ACTIONS(120),
-    [aux_sym_document_token1] = ACTIONS(122),
-    [anon_sym_TAB] = ACTIONS(122),
-    [sym_text] = ACTIONS(122),
-    [aux_sym_number_token1] = ACTIONS(122),
-    [aux_sym_number_token2] = ACTIONS(122),
-    [aux_sym_float_token1] = ACTIONS(122),
-    [aux_sym_float_token2] = ACTIONS(122),
-    [anon_sym_true] = ACTIONS(122),
-    [anon_sym_false] = ACTIONS(122),
-  },
-  [27] = {
-    [ts_builtin_sym_end] = ACTIONS(124),
-    [aux_sym_document_token1] = ACTIONS(126),
-    [anon_sym_TAB] = ACTIONS(126),
-    [sym_text] = ACTIONS(126),
-    [aux_sym_number_token1] = ACTIONS(126),
-    [aux_sym_number_token2] = ACTIONS(126),
-    [aux_sym_float_token1] = ACTIONS(126),
-    [aux_sym_float_token2] = ACTIONS(126),
-    [anon_sym_true] = ACTIONS(126),
-    [anon_sym_false] = ACTIONS(126),
-  },
-  [28] = {
-    [ts_builtin_sym_end] = ACTIONS(23),
-    [aux_sym_document_token1] = ACTIONS(25),
-    [anon_sym_TAB] = ACTIONS(25),
-    [sym_text] = ACTIONS(25),
-    [aux_sym_number_token1] = ACTIONS(25),
-    [aux_sym_number_token2] = ACTIONS(25),
-    [aux_sym_float_token1] = ACTIONS(25),
-    [aux_sym_float_token2] = ACTIONS(25),
-    [anon_sym_true] = ACTIONS(25),
-    [anon_sym_false] = ACTIONS(25),
-  },
-  [29] = {
-    [ts_builtin_sym_end] = ACTIONS(128),
-    [aux_sym_document_token1] = ACTIONS(130),
-    [anon_sym_TAB] = ACTIONS(130),
-    [sym_text] = ACTIONS(130),
-    [aux_sym_number_token1] = ACTIONS(130),
-    [aux_sym_number_token2] = ACTIONS(130),
-    [aux_sym_float_token1] = ACTIONS(130),
-    [aux_sym_float_token2] = ACTIONS(130),
-    [anon_sym_true] = ACTIONS(130),
-    [anon_sym_false] = ACTIONS(130),
-  },
-  [30] = {
-    [ts_builtin_sym_end] = ACTIONS(132),
-    [aux_sym_document_token1] = ACTIONS(134),
-    [anon_sym_TAB] = ACTIONS(134),
-    [sym_text] = ACTIONS(134),
-    [aux_sym_number_token1] = ACTIONS(134),
-    [aux_sym_number_token2] = ACTIONS(134),
-    [aux_sym_float_token1] = ACTIONS(134),
-    [aux_sym_float_token2] = ACTIONS(134),
-    [anon_sym_true] = ACTIONS(134),
-    [anon_sym_false] = ACTIONS(134),
+    [sym_field] = STATE(23),
+    [sym_number] = STATE(21),
+    [sym_float] = STATE(21),
+    [sym_boolean] = STATE(21),
+    [aux_sym_number_token1] = ACTIONS(29),
+    [aux_sym_number_token2] = ACTIONS(29),
+    [aux_sym_float_token1] = ACTIONS(31),
+    [aux_sym_float_token2] = ACTIONS(31),
+    [anon_sym_true] = ACTIONS(33),
+    [anon_sym_false] = ACTIONS(33),
+    [sym_text] = ACTIONS(35),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 1,
-    ACTIONS(122), 9,
-      aux_sym_document_token1,
-      anon_sym_TAB,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [12] = 1,
-    ACTIONS(126), 9,
-      aux_sym_document_token1,
-      anon_sym_TAB,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [24] = 1,
-    ACTIONS(130), 9,
-      aux_sym_document_token1,
-      anon_sym_TAB,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [36] = 2,
-    ACTIONS(48), 2,
-      ts_builtin_sym_end,
-      anon_sym_TAB,
-    ACTIONS(136), 7,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [50] = 1,
-    ACTIONS(134), 9,
-      aux_sym_document_token1,
-      anon_sym_TAB,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [62] = 1,
-    ACTIONS(25), 9,
-      aux_sym_document_token1,
-      anon_sym_TAB,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [74] = 3,
-    ACTIONS(138), 1,
-      anon_sym_TAB,
-    STATE(37), 1,
-      aux_sym_row_repeat1,
-    ACTIONS(112), 7,
-      sym_text,
-      aux_sym_number_token1,
-      aux_sym_number_token2,
-      aux_sym_float_token1,
-      aux_sym_float_token2,
-      anon_sym_true,
-      anon_sym_false,
-  [90] = 2,
+  [0] = 2,
     ACTIONS(15), 1,
       ts_builtin_sym_end,
-    ACTIONS(141), 1,
-      aux_sym_document_token1,
-  [97] = 2,
-    ACTIONS(141), 1,
-      aux_sym_document_token1,
-    ACTIONS(143), 1,
+    ACTIONS(37), 7,
+      aux_sym_number_token1,
+      aux_sym_number_token2,
+      aux_sym_float_token1,
+      aux_sym_float_token2,
+      anon_sym_true,
+      anon_sym_false,
+      sym_text,
+  [13] = 4,
+    ACTIONS(39), 1,
       ts_builtin_sym_end,
-  [104] = 1,
-    ACTIONS(141), 1,
+    ACTIONS(41), 1,
       aux_sym_document_token1,
-  [108] = 1,
-    ACTIONS(145), 1,
+    ACTIONS(43), 1,
+      anon_sym_TAB,
+    STATE(8), 1,
+      aux_sym_row_repeat1,
+  [26] = 4,
+    ACTIONS(43), 1,
+      anon_sym_TAB,
+    ACTIONS(45), 1,
+      ts_builtin_sym_end,
+    ACTIONS(47), 1,
+      aux_sym_document_token1,
+    STATE(9), 1,
+      aux_sym_row_repeat1,
+  [39] = 4,
+    ACTIONS(49), 1,
+      ts_builtin_sym_end,
+    ACTIONS(51), 1,
+      aux_sym_document_token1,
+    ACTIONS(53), 1,
+      anon_sym_TAB,
+    STATE(9), 1,
+      aux_sym_row_repeat1,
+  [52] = 3,
+    ACTIONS(41), 1,
+      aux_sym_document_token1,
+    ACTIONS(56), 1,
+      anon_sym_TAB,
+    STATE(16), 1,
+      aux_sym_row_repeat1,
+  [62] = 2,
+    ACTIONS(58), 1,
+      ts_builtin_sym_end,
+    ACTIONS(60), 2,
+      aux_sym_document_token1,
+      anon_sym_TAB,
+  [70] = 2,
+    ACTIONS(62), 1,
+      ts_builtin_sym_end,
+    ACTIONS(64), 2,
+      aux_sym_document_token1,
+      anon_sym_TAB,
+  [78] = 2,
+    ACTIONS(66), 1,
+      ts_builtin_sym_end,
+    ACTIONS(68), 2,
+      aux_sym_document_token1,
+      anon_sym_TAB,
+  [86] = 2,
+    ACTIONS(70), 1,
+      ts_builtin_sym_end,
+    ACTIONS(72), 2,
+      aux_sym_document_token1,
+      anon_sym_TAB,
+  [94] = 3,
+    ACTIONS(51), 1,
+      aux_sym_document_token1,
+    ACTIONS(74), 1,
+      anon_sym_TAB,
+    STATE(15), 1,
+      aux_sym_row_repeat1,
+  [104] = 3,
+    ACTIONS(47), 1,
+      aux_sym_document_token1,
+    ACTIONS(56), 1,
+      anon_sym_TAB,
+    STATE(15), 1,
+      aux_sym_row_repeat1,
+  [114] = 2,
+    ACTIONS(49), 1,
+      ts_builtin_sym_end,
+    ACTIONS(51), 2,
+      aux_sym_document_token1,
+      anon_sym_TAB,
+  [122] = 1,
+    ACTIONS(60), 2,
+      aux_sym_document_token1,
+      anon_sym_TAB,
+  [127] = 1,
+    ACTIONS(64), 2,
+      aux_sym_document_token1,
+      anon_sym_TAB,
+  [132] = 1,
+    ACTIONS(68), 2,
+      aux_sym_document_token1,
+      anon_sym_TAB,
+  [137] = 1,
+    ACTIONS(72), 2,
+      aux_sym_document_token1,
+      anon_sym_TAB,
+  [142] = 2,
+    ACTIONS(77), 1,
+      ts_builtin_sym_end,
+    ACTIONS(79), 1,
+      aux_sym_document_token1,
+  [149] = 1,
+    ACTIONS(51), 2,
+      aux_sym_document_token1,
+      anon_sym_TAB,
+  [154] = 2,
+    ACTIONS(13), 1,
+      ts_builtin_sym_end,
+    ACTIONS(79), 1,
+      aux_sym_document_token1,
+  [161] = 1,
+    ACTIONS(79), 1,
+      aux_sym_document_token1,
+  [165] = 1,
+    ACTIONS(81), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(31)] = 0,
-  [SMALL_STATE(32)] = 12,
-  [SMALL_STATE(33)] = 24,
-  [SMALL_STATE(34)] = 36,
-  [SMALL_STATE(35)] = 50,
-  [SMALL_STATE(36)] = 62,
-  [SMALL_STATE(37)] = 74,
-  [SMALL_STATE(38)] = 90,
-  [SMALL_STATE(39)] = 97,
-  [SMALL_STATE(40)] = 104,
-  [SMALL_STATE(41)] = 108,
+  [SMALL_STATE(6)] = 0,
+  [SMALL_STATE(7)] = 13,
+  [SMALL_STATE(8)] = 26,
+  [SMALL_STATE(9)] = 39,
+  [SMALL_STATE(10)] = 52,
+  [SMALL_STATE(11)] = 62,
+  [SMALL_STATE(12)] = 70,
+  [SMALL_STATE(13)] = 78,
+  [SMALL_STATE(14)] = 86,
+  [SMALL_STATE(15)] = 94,
+  [SMALL_STATE(16)] = 104,
+  [SMALL_STATE(17)] = 114,
+  [SMALL_STATE(18)] = 122,
+  [SMALL_STATE(19)] = 127,
+  [SMALL_STATE(20)] = 132,
+  [SMALL_STATE(21)] = 137,
+  [SMALL_STATE(22)] = 142,
+  [SMALL_STATE(23)] = 149,
+  [SMALL_STATE(24)] = 154,
+  [SMALL_STATE(25)] = 161,
+  [SMALL_STATE(26)] = 165,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
-  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 3, 0, 0),
-  [19] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_row, 3, 0, 0),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [23] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0),
-  [25] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0),
-  [27] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(23),
-  [30] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(30),
-  [33] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(26),
-  [36] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(27),
-  [39] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(29),
-  [42] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 2, 0, 0),
-  [44] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_row, 2, 0, 0),
-  [46] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
-  [48] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [50] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
-  [53] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(35),
-  [56] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(31),
-  [59] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(32),
-  [62] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(33),
-  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 1, 0, 0),
-  [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_row, 1, 0, 0),
-  [69] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
-  [71] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
-  [73] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
-  [75] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
-  [77] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
-  [79] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [81] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [83] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [85] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(22),
-  [88] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(35),
-  [91] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(31),
-  [94] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(32),
-  [97] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat2, 2, 0, 0), SHIFT_REPEAT(33),
-  [100] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
-  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 4, 0, 0),
-  [104] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_row, 4, 0, 0),
-  [106] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0),
-  [112] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0),
-  [114] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0), SHIFT_REPEAT(24),
-  [117] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0), SHIFT_REPEAT(25),
-  [120] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_number, 1, 0, 0),
-  [122] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_number, 1, 0, 0),
-  [124] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1, 0, 0),
-  [126] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1, 0, 0),
-  [128] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean, 1, 0, 0),
-  [130] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_boolean, 1, 0, 0),
-  [132] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_field, 1, 0, 0),
-  [134] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_field, 1, 0, 0),
-  [136] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [138] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_row_repeat1, 2, 0, 0), SHIFT_REPEAT(37),
-  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [143] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 0),
-  [145] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
+  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1),
+  [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
+  [17] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(18),
+  [20] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(19),
+  [23] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(20),
+  [26] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(21),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
+  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
+  [37] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2),
+  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 1),
+  [41] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_row, 1),
+  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
+  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_row, 2),
+  [47] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_row, 2),
+  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_row_repeat1, 2),
+  [51] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2),
+  [53] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2), SHIFT_REPEAT(4),
+  [56] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
+  [58] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_number, 1),
+  [60] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_number, 1),
+  [62] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float, 1),
+  [64] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float, 1),
+  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean, 1),
+  [68] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_boolean, 1),
+  [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_field, 1),
+  [72] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_field, 1),
+  [74] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_row_repeat1, 2), SHIFT_REPEAT(5),
+  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2),
+  [79] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [81] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
 };
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-#ifdef TREE_SITTER_HIDE_SYMBOLS
-#define TS_PUBLIC
-#elif defined(_WIN32)
-#define TS_PUBLIC __declspec(dllexport)
-#else
-#define TS_PUBLIC __attribute__((visibility("default")))
+#ifdef _WIN32
+#define extern __declspec(dllexport)
 #endif
 
-TS_PUBLIC const TSLanguage *tree_sitter_tsv(void) {
+extern const TSLanguage *tree_sitter_tsv(void) {
   static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,

--- a/tsv/src/tree_sitter/parser.h
+++ b/tsv/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -86,11 +87,6 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
-typedef struct {
-  int32_t start;
-  int32_t end;
-} TSCharacterRange;
-
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -130,38 +126,13 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
-  uint32_t index = 0;
-  uint32_t size = len - index;
-  while (size > 1) {
-    uint32_t half_size = size / 2;
-    uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
-    if (lookahead >= range->start && lookahead <= range->end) {
-      return true;
-    } else if (lookahead > range->end) {
-      index = mid_index;
-    }
-    size -= half_size;
-  }
-  TSCharacterRange *range = &ranges[index];
-  return (lookahead >= range->start && lookahead <= range->end);
-}
-
 /*
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -175,17 +146,6 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {                          \
     state = state_value;     \
     goto next_state;         \
-  }
-
-#define ADVANCE_MAP(...)                                              \
-  {                                                                   \
-    static const uint16_t map[] = { __VA_ARGS__ };                    \
-    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
-      if (map[i] == lookahead) {                                      \
-        state = map[i + 1];                                           \
-        goto next_state;                                              \
-      }                                                               \
-    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -206,7 +166,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -216,7 +176,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -224,7 +184,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}
@@ -237,15 +197,14 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }                                 \
   }}
 
-#define REDUCE(symbol_name, children, precedence, prod_id) \
-  {{                                                       \
-    .reduce = {                                            \
-      .type = TSParseActionTypeReduce,                     \
-      .symbol = symbol_name,                               \
-      .child_count = children,                             \
-      .dynamic_precedence = precedence,                    \
-      .production_id = prod_id                             \
-    },                                                     \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
   }}
 
 #define RECOVER()                    \


### PR DESCRIPTION
For example, "2025-03-01" would previously be parsed as two separate fields, a number one and a text one. This fixes the parser to parse it correctly as text.